### PR TITLE
Update workspace default member to GUI crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
     "crates/psu-packer",
     "crates/psu-packer-gui",
 ]
-default-members = ["crates/psu-packer"]
+default-members = ["crates/psu-packer-gui"]
 
 [workspace.package]
 edition = "2021"


### PR DESCRIPTION
## Summary
- switch the workspace default member to the psu-packer-gui crate

## Testing
- cargo build --release

------
https://chatgpt.com/codex/tasks/task_e_68c83d861f148321aa79540855ff8f44