### PR TITLE
Organize PSU packer GUI sections vertically

### DIFF
--- a/crates/psu-packer-gui/src/main.rs
+++ b/crates/psu-packer-gui/src/main.rs
@@ -188,19 +188,22 @@ impl PackerApp {
                         }
                     }
                 });
+        }
 
-            ui.horizontal(|ui| {
-                if ui.button("Add file").clicked() {
-                    add_clicked = true;
-                }
+        let selected_exists = {
+            let (_, selected) = self.current_list();
+            selected.is_some()
+        };
 
-                if ui
-                    .add_enabled(selected.is_some(), egui::Button::new("Remove file"))
-                    .clicked()
-                {
-                    remove_clicked = true;
-                }
-            });
+        if ui.button("Add file").clicked() {
+            add_clicked = true;
+        }
+
+        if ui
+            .add_enabled(selected_exists, egui::Button::new("Remove file"))
+            .clicked()
+        {
+            remove_clicked = true;
         }
 
         if add_clicked {
@@ -305,124 +308,189 @@ impl PackerApp {
 impl eframe::App for PackerApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
-            if ui.button("Select folder").clicked() {
-                if let Some(dir) = rfd::FileDialog::new().pick_folder() {
-                    match psu_packer::load_config(&dir) {
-                        Ok(config) => {
-                            let psu_packer::Config {
-                                name,
-                                timestamp,
-                                include,
-                                exclude,
-                            } = config;
+            ui.group(|ui| {
+                ui.heading("Folder");
+                ui.small("Select the PSU project folder containing psu.toml.");
+                if ui
+                    .button("Select folder")
+                    .on_hover_text("Pick the source directory to load configuration values.")
+                    .clicked()
+                {
+                    if let Some(dir) = rfd::FileDialog::new().pick_folder() {
+                        match psu_packer::load_config(&dir) {
+                            Ok(config) => {
+                                let psu_packer::Config {
+                                    name,
+                                    timestamp,
+                                    include,
+                                    exclude,
+                                } = config;
 
-                            let include_present = include.is_some();
-                            let exclude_present = exclude.is_some();
+                                let include_present = include.is_some();
+                                let exclude_present = exclude.is_some();
 
-                            self.output = format!("{}.psu", name);
-                            self.name = name;
-                            self.timestamp = timestamp
-                                .map(|t| t.format(TIMESTAMP_FORMAT).to_string())
-                                .unwrap_or_default();
-                            self.file_mode = if include_present {
-                                FileMode::Include
-                            } else {
-                                FileMode::Exclude
-                            };
-                            self.include_files = include.unwrap_or_default();
-                            self.exclude_files = exclude.unwrap_or_default();
-                            self.selected_include = None;
-                            self.selected_exclude = None;
-                            self.clear_error_message();
-                            self.status.clear();
-                            if include_present && exclude_present {
-                                self.status = "Config contains both include and exclude lists; using include list"
-                                    .to_string();
+                                self.output = format!("{}.psu", name);
+                                self.name = name;
+                                self.timestamp = timestamp
+                                    .map(|t| t.format(TIMESTAMP_FORMAT).to_string())
+                                    .unwrap_or_default();
+                                self.file_mode = if include_present {
+                                    FileMode::Include
+                                } else {
+                                    FileMode::Exclude
+                                };
+                                self.include_files = include.unwrap_or_default();
+                                self.exclude_files = exclude.unwrap_or_default();
+                                self.selected_include = None;
+                                self.selected_exclude = None;
+                                self.clear_error_message();
+                                self.status.clear();
+                                if include_present && exclude_present {
+                                    self.status = "Config contains both include and exclude lists; using include list"
+                                        .to_string();
+                                }
+                            }
+                            Err(err) => {
+                                let message = PackerApp::format_load_error(&dir, err);
+                                self.set_error_message(message);
+                                self.output.clear();
+                                self.name.clear();
+                                self.timestamp.clear();
+                                self.file_mode = FileMode::default();
+                                self.include_files.clear();
+                                self.exclude_files.clear();
+                                self.selected_include = None;
+                                self.selected_exclude = None;
                             }
                         }
-                        Err(err) => {
-                            let message = PackerApp::format_load_error(&dir, err);
-                            self.set_error_message(message);
-                            self.output.clear();
-                            self.name.clear();
-                            self.timestamp.clear();
-                            self.file_mode = FileMode::default();
-                            self.include_files.clear();
-                            self.exclude_files.clear();
-                            self.selected_include = None;
-                            self.selected_exclude = None;
-                        }
+                        self.folder = Some(dir);
                     }
-                    self.folder = Some(dir);
                 }
-            }
-            if let Some(folder) = &self.folder {
-                ui.label(format!("Folder: {}", folder.display()));
-            }
-            if !self.name.is_empty() || self.folder.is_some() {
-                ui.horizontal(|ui| {
-                    ui.label("Name:");
-                    ui.text_edit_singleline(&mut self.name);
-                });
-                ui.horizontal(|ui| {
-                    ui.label("Timestamp:");
-                    ui.text_edit_singleline(&mut self.timestamp);
-                });
-                ui.horizontal(|ui| {
-                    ui.label("File mode:");
-                    ui.radio_value(&mut self.file_mode, FileMode::Include, "Include");
-                    ui.radio_value(&mut self.file_mode, FileMode::Exclude, "Exclude");
-                });
-                self.file_list_ui(ui);
-            }
-            ui.horizontal(|ui| {
-                ui.label("Output:");
-                ui.text_edit_singleline(&mut self.output);
-                if ui.button("Browse").clicked() {
-                    if let Some(file) = rfd::FileDialog::new()
-                        .set_file_name(&self.output)
-                        .save_file()
-                    {
-                        self.output = file.display().to_string();
-                    }
+
+                if let Some(folder) = &self.folder {
+                    ui.label(format!("Folder: {}", folder.display()));
                 }
             });
-            if ui.button("Pack").clicked() {
-                if let Some(folder) = &self.folder {
-                    if self.name.trim().is_empty() {
-                        self.set_error_message("Please provide a PSU name");
-                        return;
-                    }
 
-                    let config = match self.build_config() {
-                        Ok(config) => config,
-                        Err(err) => {
-                            self.set_error_message(err);
+            ui.add_space(8.0);
+
+            ui.group(|ui| {
+                ui.heading("Metadata");
+                ui.small("Review or edit metadata loaded from the selected folder.");
+                if self.folder.is_some() || !self.name.is_empty() {
+                    egui::Grid::new("metadata_grid")
+                        .num_columns(2)
+                        .spacing(egui::vec2(12.0, 6.0))
+                        .show(ui, |ui| {
+                            ui.label("Name");
+                            ui.text_edit_singleline(&mut self.name);
+                            ui.end_row();
+
+                            ui.label("Timestamp");
+                            ui.text_edit_singleline(&mut self.timestamp);
+                            ui.end_row();
+
+                            ui.label("File mode");
+                            ui.vertical(|ui| {
+                                ui.radio_value(&mut self.file_mode, FileMode::Include, "Include");
+                                ui.radio_value(&mut self.file_mode, FileMode::Exclude, "Exclude");
+                            });
+                            ui.end_row();
+                        });
+                } else {
+                    ui.label("Select a folder to load metadata options.");
+                }
+            });
+
+            ui.add_space(8.0);
+
+            ui.group(|ui| {
+                ui.heading("File filters");
+                ui.small("Manage include or exclude lists before creating the archive.");
+                if self.folder.is_some() || !self.name.is_empty() {
+                    self.file_list_ui(ui);
+                } else {
+                    ui.label("Select a folder to configure file filters.");
+                }
+            });
+
+            ui.add_space(8.0);
+
+            ui.group(|ui| {
+                ui.heading("Output");
+                ui.small("Choose where the packed PSU file will be saved.");
+                egui::Grid::new("output_grid")
+                    .num_columns(2)
+                    .spacing(egui::vec2(12.0, 6.0))
+                    .show(ui, |ui| {
+                        ui.label("File path");
+                        ui.text_edit_singleline(&mut self.output);
+                        ui.end_row();
+
+                        ui.label("");
+                        if ui
+                            .button("Browse")
+                            .on_hover_text("Set a custom destination for the PSU file.")
+                            .clicked()
+                        {
+                            if let Some(file) = rfd::FileDialog::new()
+                                .set_file_name(&self.output)
+                                .save_file()
+                            {
+                                self.output = file.display().to_string();
+                            }
+                        }
+                        ui.end_row();
+                    });
+            });
+
+            ui.add_space(8.0);
+
+            ui.group(|ui| {
+                ui.heading("Packaging");
+                ui.small("Validate the configuration and generate the PSU archive.");
+                if ui
+                    .button("Pack")
+                    .on_hover_text("Create the PSU archive using the settings above.")
+                    .clicked()
+                {
+                    if let Some(folder) = &self.folder {
+                        if self.name.trim().is_empty() {
+                            self.set_error_message("Please provide a PSU name");
                             return;
                         }
-                    };
 
-                    let output_path = PathBuf::from(&self.output);
-                    match psu_packer::pack_with_config(folder, &output_path, config) {
-                        Ok(_) => {
-                            self.status = format!("Packed to {}", output_path.display());
-                            self.clear_error_message();
+                        let config = match self.build_config() {
+                            Ok(config) => config,
+                            Err(err) => {
+                                self.set_error_message(err);
+                                return;
+                            }
+                        };
+
+                        let output_path = PathBuf::from(&self.output);
+                        match psu_packer::pack_with_config(folder, &output_path, config) {
+                            Ok(_) => {
+                                self.status = format!("Packed to {}", output_path.display());
+                                self.clear_error_message();
+                            }
+                            Err(err) => {
+                                let message = self.format_pack_error(folder, &output_path, err);
+                                self.set_error_message(message);
+                            }
                         }
-                        Err(err) => {
-                            let message = self.format_pack_error(folder, &output_path, err);
-                            self.set_error_message(message);
-                        }
+                    } else {
+                        self.set_error_message("Please select a folder");
                     }
-                } else {
-                    self.set_error_message("Please select a folder");
                 }
-            }
-            if let Some(error) = &self.error_message {
-                ui.colored_label(egui::Color32::RED, error);
-            }
-            if !self.status.is_empty() {
-                ui.label(&self.status);
-            }
+
+                if let Some(error) = &self.error_message {
+                    ui.colored_label(egui::Color32::RED, error);
+                }
+                if !self.status.is_empty() {
+                    ui.label(&self.status);
+                }
+            });
         });
     }
 }


### PR DESCRIPTION
## Summary
- restructure the PSU packer GUI into grouped sections for folder selection, metadata, filters, output, and packaging
- replace horizontal layouts with vertical and grid layouts so each input is on its own line and add helper text for each section
- adjust the file list controls to stack actions vertically while preserving selection handling

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68c887324bd483219652040e65ab2c81