### PR TITLE
Add PSU import workflow to GUI

### DIFF
--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 
 [dependencies]
 psu-packer = { path = "../psu-packer" }
+ps2-filetypes = { path = "../ps2-filetypes" }
 eframe = "0.27"
 rfd = "0.14"
 chrono = "0.4.42"


### PR DESCRIPTION
## Summary
- add ps2-filetypes dependency so the GUI can parse PSU archives
- add an "Open PSU" action that loads metadata and file entries from a chosen PSU file
- surface the loaded archive contents in a read-only section and prefill the existing configuration fields

## Testing
- cargo check -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68c88923bf9c83218a510f5ae5a6b260