### PR TITLE
Add menu bar to PSU packer GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4090,6 +4090,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "eframe 0.27.2",
+ "ps2-filetypes",
  "psu-packer",
  "rfd 0.14.1",
 ]


### PR DESCRIPTION
## Summary
- add a top File menu in the PSU packer GUI with save, open, and exit actions
- reuse the output save dialog helper and remove the duplicate "Open PSU" button
- record the ps2-filetypes dependency in the lock file for psu-packer-gui

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68c8a55eb0188321b0c6b1c97c552182