### PR TITLE
Add timestamp hint text in GUI

### DIFF
--- a/crates/psu-packer-gui/src/main.rs
+++ b/crates/psu-packer-gui/src/main.rs
@@ -626,7 +626,7 @@ impl eframe::App for PackerApp {
                             ui.end_row();
 
                             ui.label("Timestamp");
-                            ui.text_edit_singleline(&mut self.timestamp);
+                            ui.add(egui::TextEdit::singleline(&mut self.timestamp).hint_text(TIMESTAMP_FORMAT));
                             ui.end_row();
 
                             ui.label("File mode");


### PR DESCRIPTION
## Summary
- use an egui text edit with a hint for the timestamp field so the expected format is visible

## Testing
- cargo fmt --all -- --check (fails: existing formatting differences in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68c8b646a3888321aa23917287f4f780