### PR TITLE
Add configurable icon.sys generation support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,47 @@ Graphical interface for packing PSU archives. Run with:
 cargo run -p psu-packer-gui
 ```
 
+### Configuring icon.sys metadata
+
+`psu-packer` now understands an optional `[icon_sys]` table inside `psu.toml`. When the table is present—or when the GUI toggle is enabled—the packer regenerates `icon.sys` before packaging and automatically includes it even if the file is missing from the `include` list.
+
+#### Example `psu.toml`
+
+```toml
+[config]
+name = "Example Save"
+timestamp = "2024-10-10 10:30:00"
+include = ["BOOT.ELF", "TITLE.DB"]
+
+[icon_sys]
+flags = "PS2 Save File"
+title = "Example Save"
+background_transparency = 0
+background_colors = [
+    { r = 0, g = 32, b = 96, a = 0 },
+    { r = 0, g = 48, b = 128, a = 0 },
+    { r = 0, g = 64, b = 160, a = 0 },
+    { r = 0, g = 16, b = 48, a = 0 },
+]
+light_directions = [
+    { x = 0.0, y = 0.0, z = 1.0, w = 0.0 },
+    { x = -0.5, y = -0.5, z = 0.5, w = 0.0 },
+    { x = 0.5, y = -0.5, z = 0.5, w = 0.0 },
+]
+light_colors = [
+    { r = 1.0, g = 1.0, b = 1.0, a = 1.0 },
+    { r = 0.5, g = 0.5, b = 0.6, a = 1.0 },
+    { r = 0.3, g = 0.3, b = 0.4, a = 1.0 },
+]
+ambient_color = { r = 0.2, g = 0.2, b = 0.2, a = 1.0 }
+```
+
+* `flags` accepts either a numeric value or one of the descriptive names from the GUI drop-down (for example `"PS2 Save File"`, `"Software (PS2)"`, or `"System Driver"`).
+* `background_colors` must contain exactly four entries; `light_directions` and `light_colors` expect three entries each. Omit these arrays to keep the defaults.
+* `ambient_color` and `background_transparency` are optional—leave them out to rely on the standard lighting values bundled with the packer.
+
+The GUI mirrors the same settings so you can preview and persist changes without touching the TOML by hand.
+
 ## Credits
 
 Icon & UI Design by [@Berion](https://www.psx-place.com/members/berion.1431/)

--- a/crates/psu-packer/src/lib.rs
+++ b/crates/psu-packer/src/lib.rs
@@ -1,18 +1,21 @@
 use chrono::{DateTime, Local, NaiveDateTime};
 use colored::Colorize;
-use ps2_filetypes::{PSUEntry, PSUEntryKind, PSUWriter, DIR_ID, FILE_ID, PSU};
-use serde::Deserialize;
+use ps2_filetypes::color::Color;
+use ps2_filetypes::{
+    ColorF, IconSys, PSUEntry, PSUEntryKind, PSUWriter, Vector, DIR_ID, FILE_ID, PSU,
+};
+use serde::{Deserialize, Deserializer};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub struct Config {
     pub name: String,
-    #[serde(default, with = "date_format")]
     pub timestamp: Option<NaiveDateTime>,
     pub include: Option<Vec<String>>,
     pub exclude: Option<Vec<String>>,
+    pub icon_sys: Option<IconSysConfig>,
 }
 
 mod date_format {
@@ -37,16 +40,381 @@ mod date_format {
 
 #[derive(Debug, Deserialize)]
 struct ConfigFile {
-    config: Config,
+    config: ConfigSection,
+    #[serde(default)]
+    icon_sys: Option<IconSysConfig>,
 }
+
+#[derive(Debug, Deserialize)]
+struct ConfigSection {
+    name: String,
+    #[serde(default, with = "date_format")]
+    timestamp: Option<NaiveDateTime>,
+    include: Option<Vec<String>>,
+    exclude: Option<Vec<String>>,
+}
+
+impl From<ConfigFile> for Config {
+    fn from(file: ConfigFile) -> Self {
+        let ConfigFile { config, icon_sys } = file;
+        Self {
+            name: config.name,
+            timestamp: config.timestamp,
+            include: config.include,
+            exclude: config.exclude,
+            icon_sys,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IconSysConfig {
+    pub flags: IconSysFlags,
+    pub title: String,
+    #[serde(default)]
+    pub background_transparency: Option<u32>,
+    #[serde(default)]
+    pub background_colors: Option<Vec<ColorConfig>>,
+    #[serde(default)]
+    pub light_directions: Option<Vec<VectorConfig>>,
+    #[serde(default)]
+    pub light_colors: Option<Vec<ColorFConfig>>,
+    #[serde(default)]
+    pub ambient_color: Option<ColorFConfig>,
+}
+
+impl IconSysConfig {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        let icon_sys = self.build_icon_sys()?;
+        icon_sys
+            .to_bytes()
+            .map_err(|err| Error::ConfigError(err.to_string()))
+    }
+
+    fn build_icon_sys(&self) -> Result<IconSys, Error> {
+        let mut background_colors = DEFAULT_BACKGROUND_COLORS;
+        if let Some(colors) = &self.background_colors {
+            if colors.len() != background_colors.len() {
+                return Err(Error::ConfigError(format!(
+                    "icon_sys.background_colors must contain exactly {} entries",
+                    background_colors.len()
+                )));
+            }
+
+            for (target, value) in background_colors.iter_mut().zip(colors.iter()) {
+                *target = (*value).into();
+            }
+        }
+
+        let mut light_directions = DEFAULT_LIGHT_DIRECTIONS;
+        if let Some(directions) = &self.light_directions {
+            if directions.len() != light_directions.len() {
+                return Err(Error::ConfigError(format!(
+                    "icon_sys.light_directions must contain exactly {} entries",
+                    light_directions.len()
+                )));
+            }
+
+            for (target, value) in light_directions.iter_mut().zip(directions.iter()) {
+                *target = (*value).into();
+            }
+        }
+
+        let mut light_colors = DEFAULT_LIGHT_COLORS;
+        if let Some(colors) = &self.light_colors {
+            if colors.len() != light_colors.len() {
+                return Err(Error::ConfigError(format!(
+                    "icon_sys.light_colors must contain exactly {} entries",
+                    light_colors.len()
+                )));
+            }
+
+            for (target, value) in light_colors.iter_mut().zip(colors.iter()) {
+                *target = (*value).into();
+            }
+        }
+
+        let ambient_color = self
+            .ambient_color
+            .map(|color| color.into())
+            .unwrap_or(DEFAULT_AMBIENT_COLOR);
+
+        let background_transparency = self
+            .background_transparency
+            .unwrap_or(DEFAULT_BACKGROUND_TRANSPARENCY);
+
+        Ok(IconSys {
+            flags: self.flags.value(),
+            linebreak_pos: DEFAULT_LINEBREAK_POS,
+            background_transparency,
+            background_colors,
+            light_directions,
+            light_colors,
+            ambient_color,
+            title: self.title.clone(),
+            icon_file: ICON_FILE_NAME.to_string(),
+            icon_copy_file: ICON_FILE_NAME.to_string(),
+            icon_delete_file: ICON_FILE_NAME.to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+pub struct ColorConfig {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8,
+}
+
+impl From<ColorConfig> for Color {
+    fn from(value: ColorConfig) -> Self {
+        Color {
+            r: value.r,
+            g: value.g,
+            b: value.b,
+            a: value.a,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+pub struct ColorFConfig {
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+    pub a: f32,
+}
+
+impl From<ColorFConfig> for ColorF {
+    fn from(value: ColorFConfig) -> Self {
+        ColorF {
+            r: value.r,
+            g: value.g,
+            b: value.b,
+            a: value.a,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+pub struct VectorConfig {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
+}
+
+impl From<VectorConfig> for Vector {
+    fn from(value: VectorConfig) -> Self {
+        Vector {
+            x: value.x,
+            y: value.y,
+            z: value.z,
+            w: value.w,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IconSysFlags(u16);
+
+impl IconSysFlags {
+    pub const fn new(value: u16) -> Self {
+        Self(value)
+    }
+
+    pub const fn value(self) -> u16 {
+        self.0
+    }
+}
+
+impl From<u16> for IconSysFlags {
+    fn from(value: u16) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<IconSysFlags> for u16 {
+    fn from(value: IconSysFlags) -> Self {
+        value.value()
+    }
+}
+
+impl<'de> Deserialize<'de> for IconSysFlags {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct IconSysFlagsVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for IconSysFlagsVisitor {
+            type Value = IconSysFlags;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("an icon.sys flag value or descriptive name")
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if value > u16::MAX as u64 {
+                    return Err(E::custom("icon_sys.flags must be between 0 and 65535"));
+                }
+                Ok(IconSysFlags::new(value as u16))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if !(0..=u16::MAX as i64).contains(&value) {
+                    return Err(E::custom("icon_sys.flags must be between 0 and 65535"));
+                }
+                Ok(IconSysFlags::new(value as u16))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                parse_flag_string(value)
+                    .map(IconSysFlags::new)
+                    .map_err(E::custom)
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_str(&value)
+            }
+        }
+
+        deserializer.deserialize_any(IconSysFlagsVisitor)
+    }
+}
+
+fn parse_flag_string(value: &str) -> Result<u16, String> {
+    let trimmed = value.trim();
+    if let Some(mapped) = parse_named_flag(trimmed) {
+        return Ok(mapped);
+    }
+
+    if let Some(stripped) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        return u16::from_str_radix(stripped, 16)
+            .map_err(|_| format!("Invalid hexadecimal icon_sys flag: {trimmed}"));
+    }
+
+    trimmed
+        .parse::<u16>()
+        .map_err(|_| format!("Invalid icon_sys flag value: {trimmed}"))
+}
+
+fn parse_named_flag(value: &str) -> Option<u16> {
+    let normalized: String = value
+        .to_ascii_lowercase()
+        .chars()
+        .filter(|c| !c.is_ascii_whitespace() && *c != '_' && *c != '(' && *c != ')')
+        .collect();
+
+    match normalized.as_str() {
+        "ps2savefile" | "savefile" => Some(0),
+        "softwareps2" | "software" => Some(1),
+        "unrecognizeddata" | "unrecognized" | "data" => Some(2),
+        "softwarepocketstation" | "pocketstation" => Some(3),
+        "settingsps2" | "settings" => Some(4),
+        "systemdriver" | "driver" => Some(5),
+        _ => None,
+    }
+}
+
+const DEFAULT_LINEBREAK_POS: u16 = 0;
+const DEFAULT_BACKGROUND_TRANSPARENCY: u32 = 0;
+const DEFAULT_BACKGROUND_COLORS: [Color; 4] = [
+    Color {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 0,
+    },
+    Color {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 0,
+    },
+    Color {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 0,
+    },
+    Color {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 0,
+    },
+];
+const DEFAULT_LIGHT_DIRECTIONS: [Vector; 3] = [
+    Vector {
+        x: 0.0,
+        y: 0.0,
+        z: 1.0,
+        w: 0.0,
+    },
+    Vector {
+        x: 0.0,
+        y: 0.0,
+        z: 1.0,
+        w: 0.0,
+    },
+    Vector {
+        x: 0.0,
+        y: 0.0,
+        z: 1.0,
+        w: 0.0,
+    },
+];
+const DEFAULT_LIGHT_COLORS: [ColorF; 3] = [
+    ColorF {
+        r: 1.0,
+        g: 1.0,
+        b: 1.0,
+        a: 1.0,
+    },
+    ColorF {
+        r: 0.5,
+        g: 0.5,
+        b: 0.5,
+        a: 1.0,
+    },
+    ColorF {
+        r: 0.3,
+        g: 0.3,
+        b: 0.3,
+        a: 1.0,
+    },
+];
+const DEFAULT_AMBIENT_COLOR: ColorF = ColorF {
+    r: 0.2,
+    g: 0.2,
+    b: 0.2,
+    a: 1.0,
+};
+const ICON_FILE_NAME: &str = "icon.icn";
 
 pub fn load_config(folder: &Path) -> Result<Config, Error> {
     let config_file = folder.join("psu.toml");
     let str = std::fs::read_to_string(&config_file)?;
-    let config = toml::from_str::<ConfigFile>(&str)
-        .map_err(|e| Error::ConfigError(e.to_string()))?
-        .config;
-    Ok(config)
+    let config_file =
+        toml::from_str::<ConfigFile>(&str).map_err(|e| Error::ConfigError(e.to_string()))?;
+    Ok(config_file.into())
 }
 
 pub fn pack_psu(folder: &Path, output: &Path) -> Result<(), Error> {
@@ -60,6 +428,7 @@ pub fn pack_with_config(folder: &Path, output: &Path, cfg: Config) -> Result<(),
         timestamp,
         include,
         exclude,
+        icon_sys,
     } = cfg;
 
     if !check_name(&name) {
@@ -67,6 +436,12 @@ pub fn pack_with_config(folder: &Path, output: &Path, cfg: Config) -> Result<(),
     }
 
     let mut psu = PSU::default();
+
+    let icon_sys_path = folder.join("icon.sys");
+    if let Some(icon_config) = &icon_sys {
+        let bytes = icon_config.to_bytes()?;
+        std::fs::write(&icon_sys_path, bytes)?;
+    }
 
     let raw_included_files = if let Some(include) = include {
         include
@@ -144,6 +519,12 @@ pub fn pack_with_config(folder: &Path, output: &Path, cfg: Config) -> Result<(),
                         .unwrap_or(true)
                 })
                 .collect::<Vec<_>>();
+        }
+    }
+
+    if icon_sys.is_some() {
+        if !files.iter().any(|path| path == &icon_sys_path) {
+            files.push(icon_sys_path);
         }
     }
 


### PR DESCRIPTION
## Summary
- extend the packer to parse an optional `[icon_sys]` table, build icon metadata, and always bundle the generated file
- add GUI controls for the icon.sys flag and title so the settings persist back into `psu.toml`
- document the workflow with a sample configuration and remove the local screenshot

## Testing
- cargo test -p psu-packer
- cargo check -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68c8d045a4f0832188cbab2847e7bb8a