### PR TITLE
Ensure PSU extension when selecting output

### DIFF
--- a/crates/psu-packer-gui/src/ui/pack_controls.rs
+++ b/crates/psu-packer-gui/src/ui/pack_controls.rs
@@ -255,10 +255,21 @@ fn file_list_ui(
 
 impl PackerApp {
     pub(crate) fn browse_output_destination(&mut self) {
-        if let Some(file) = rfd::FileDialog::new()
+        if let Some(mut file) = rfd::FileDialog::new()
+            .add_filter("PSU", &["psu"])
             .set_file_name(&self.output)
             .save_file()
         {
+            let has_psu_extension = file
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext.eq_ignore_ascii_case("psu"))
+                .unwrap_or(false);
+
+            if !has_psu_extension {
+                file.set_extension("psu");
+            }
+
             self.output = file.display().to_string();
         }
     }


### PR DESCRIPTION
## Summary
- ensure the PSU packer output dialog filters for .psu files
- normalize the selected save path so it always ends with a .psu extension

## Testing
- cargo check -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68c8fb2437488321bbb24dbbb758af80