### PR TITLE
Use date and time pickers for PSU timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,10 @@ name = "accesskit"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74a4b14f3d99c1255dcba8f45621ab1a2e7540a0009652d33989005a4d0bfc6b"
+dependencies = [
+ "enumn",
+ "serde",
+]
 
 [[package]]
 name = "accesskit"
@@ -1467,6 +1471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20930a432bbd57a6d55e07976089708d4893f3d556cf42a0d79e9e321fa73b10"
 dependencies = [
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -1564,6 +1569,7 @@ dependencies = [
  "epaint 0.27.2",
  "log",
  "nohash-hasher",
+ "serde",
 ]
 
 [[package]]
@@ -1673,6 +1679,20 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b78779f35ded1a853786c9ce0b43fe1053e10a21ea3b23ebea411805ce41593"
+dependencies = [
+ "chrono",
+ "egui 0.27.2",
+ "enum-map",
+ "log",
+ "mime_guess2",
+ "serde",
+]
+
+[[package]]
+name = "egui_extras"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624659a2e972a46f4d5f646557906c55f1cd5a0836eddbe610fdf1afba1b4226"
@@ -1734,6 +1754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c3a552cfca14630702449d35f41c84a0d15963273771c6059175a803620f3f"
 dependencies = [
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -1819,6 +1840,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
+ "serde",
 ]
 
 [[package]]
@@ -4090,6 +4112,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "eframe 0.27.2",
+ "egui_extras 0.27.2",
  "ps2-filetypes",
  "psu-packer",
  "rfd 0.14.1",
@@ -4830,7 +4853,7 @@ dependencies = [
  "cgmath",
  "eframe 0.31.1",
  "egui_dock",
- "egui_extras",
+ "egui_extras 0.31.1",
  "image 0.25.6",
  "macros",
  "notify",

--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -10,3 +10,4 @@ ps2-filetypes = { path = "../ps2-filetypes" }
 eframe = "0.27"
 rfd = "0.14"
 chrono = "0.4.42"
+egui_extras = { version = "0.27", features = ["chrono"] }

--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -4,6 +4,7 @@ use std::{
     thread,
 };
 
+use chrono::NaiveDateTime;
 use eframe::egui;
 
 pub mod ui;
@@ -53,7 +54,7 @@ pub struct PackerApp {
     pub(crate) status: String,
     pub(crate) error_message: Option<String>,
     pub(crate) name: String,
-    pub(crate) timestamp: String,
+    pub(crate) timestamp: Option<NaiveDateTime>,
     pub(crate) include_files: Vec<String>,
     pub(crate) exclude_files: Vec<String>,
     pub(crate) selected_include: Option<usize>,
@@ -112,7 +113,7 @@ impl Default for PackerApp {
             status: String::new(),
             error_message: None,
             name: String::new(),
-            timestamp: String::new(),
+            timestamp: None,
             include_files: Vec::new(),
             exclude_files: Vec::new(),
             selected_include: None,
@@ -161,7 +162,7 @@ impl PackerApp {
 
     pub(crate) fn reset_metadata_fields(&mut self) {
         self.name.clear();
-        self.timestamp.clear();
+        self.timestamp = None;
         self.include_files.clear();
         self.exclude_files.clear();
         self.selected_include = None;

--- a/crates/psu-packer-gui/src/ui/file_picker.rs
+++ b/crates/psu-packer-gui/src/ui/file_picker.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use eframe::egui;
 use ps2_filetypes::{PSUEntryKind, PSU};
 
-use crate::{IconFlagSelection, PackerApp, ICON_SYS_FLAG_OPTIONS, TIMESTAMP_FORMAT};
+use crate::{IconFlagSelection, PackerApp, ICON_SYS_FLAG_OPTIONS};
 
 pub(crate) fn file_menu(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.menu_button("File", |ui| {
@@ -49,9 +49,7 @@ pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
 
                             app.output = format!("{}.psu", name);
                             app.name = name;
-                            app.timestamp = timestamp
-                                .map(|t| t.format(TIMESTAMP_FORMAT).to_string())
-                                .unwrap_or_default();
+                            app.timestamp = timestamp;
                             app.include_files = include.unwrap_or_default();
                             app.exclude_files = exclude.unwrap_or_default();
                             app.selected_include = None;
@@ -81,7 +79,7 @@ pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
                             app.set_error_message(message);
                             app.output.clear();
                             app.name.clear();
-                            app.timestamp.clear();
+                            app.timestamp = None;
                             app.include_files.clear();
                             app.exclude_files.clear();
                             app.selected_include = None;
@@ -171,9 +169,7 @@ impl PackerApp {
         };
 
         self.name = name;
-        self.timestamp = root_timestamp
-            .map(|ts| ts.format(TIMESTAMP_FORMAT).to_string())
-            .unwrap_or_default();
+        self.timestamp = root_timestamp;
         self.loaded_psu_files = files;
         self.loaded_psu_path = Some(path.clone());
         self.clear_error_message();


### PR DESCRIPTION
## Summary
- add `egui_extras` and build a date/time picker for the PSU timestamp entry
- persist the timestamp as an `Option<NaiveDateTime>` and load values from configs and PSUs without formatting strings
- build the pack configuration with the typed timestamp value instead of parsing user input

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68c9013e73bc8321a077119d6ce43aba