### PR TITLE
Add PSU TOML viewer tab

### DIFF
--- a/crates/suitcase/src/components/tab_viewer.rs
+++ b/crates/suitcase/src/components/tab_viewer.rs
@@ -1,7 +1,7 @@
 use crate::tabs::Tab;
-use eframe::egui::{Id, Ui, WidgetText};
+use crate::tabs::{ICNViewer, IconSysViewer, PsuTomlViewer, TitleCfgViewer};
 use crate::AppState;
-use crate::tabs::{IconSysViewer, TitleCfgViewer, ICNViewer};
+use eframe::egui::{Id, Ui, WidgetText};
 
 pub struct TabViewer<'a> {
     pub(crate) app: &'a mut AppState,
@@ -11,6 +11,7 @@ pub enum TabType {
     IconSysViewer(IconSysViewer),
     TitleCfgViewer(TitleCfgViewer),
     ICNViewer(ICNViewer),
+    PsuTomlViewer(PsuTomlViewer),
 }
 
 impl TabType {
@@ -19,6 +20,7 @@ impl TabType {
             TabType::IconSysViewer(tab) => tab.get_id(),
             TabType::TitleCfgViewer(tab) => tab.get_id(),
             TabType::ICNViewer(tab) => tab.get_id(),
+            TabType::PsuTomlViewer(tab) => tab.get_id(),
         }
     }
 
@@ -27,6 +29,7 @@ impl TabType {
             TabType::IconSysViewer(tab) => tab.get_title(),
             TabType::TitleCfgViewer(tab) => tab.get_title(),
             TabType::ICNViewer(tab) => tab.get_title(),
+            TabType::PsuTomlViewer(tab) => tab.get_title(),
         }
     }
 
@@ -35,6 +38,7 @@ impl TabType {
             TabType::IconSysViewer(tab) => tab.get_modified(),
             TabType::TitleCfgViewer(tab) => tab.get_modified(),
             TabType::ICNViewer(tab) => tab.get_modified(),
+            TabType::PsuTomlViewer(tab) => tab.get_modified(),
         }
     }
 
@@ -43,6 +47,7 @@ impl TabType {
             TabType::IconSysViewer(tab) => tab.save(),
             TabType::TitleCfgViewer(tab) => tab.save(),
             TabType::ICNViewer(tab) => tab.save(),
+            TabType::PsuTomlViewer(tab) => tab.save(),
         }
     }
 }
@@ -55,7 +60,8 @@ impl<'a> egui_dock::TabViewer for TabViewer<'a> {
             format!("* {}", tab.get_title())
         } else {
             tab.get_title()
-        }.into()
+        }
+        .into()
     }
 
     fn ui(&mut self, ui: &mut Ui, tab: &mut Self::Tab) {
@@ -67,6 +73,9 @@ impl<'a> egui_dock::TabViewer for TabViewer<'a> {
                 tab.show(ui);
             }
             TabType::TitleCfgViewer(tab) => {
+                tab.show(ui);
+            }
+            TabType::PsuTomlViewer(tab) => {
                 tab.show(ui);
             }
         }

--- a/crates/suitcase/src/main.rs
+++ b/crates/suitcase/src/main.rs
@@ -21,7 +21,7 @@ use crate::{
     io::export_psu::export_psu,
     io::file_watcher::FileWatcher,
     io::read_folder::read_folder,
-    tabs::{ICNViewer, IconSysViewer, TitleCfgViewer},
+    tabs::{ICNViewer, IconSysViewer, PsuTomlViewer, TitleCfgViewer},
     wizards::create_icn::create_icn_wizard,
 };
 use eframe::egui::{Context, Frame, IconData, Margin, ViewportCommand};
@@ -219,6 +219,10 @@ impl PSUBuilderApp {
                 "cfg" | "cnf" | "dat" | "txt" => Some(TabType::TitleCfgViewer(
                     TitleCfgViewer::new(&file, &self.state),
                 )),
+                "toml" => Some(TabType::PsuTomlViewer(PsuTomlViewer::new(
+                    &file,
+                    &self.state,
+                ))),
                 _ => None,
             };
 

--- a/crates/suitcase/src/tabs/mod.rs
+++ b/crates/suitcase/src/tabs/mod.rs
@@ -1,9 +1,11 @@
 pub mod icn_viewer;
 pub mod icon_sys_viewer;
+pub mod psu_toml_viewer;
 pub mod tab;
 pub mod title_cfg_viewer;
 
 pub use icn_viewer::*;
 pub use icon_sys_viewer::*;
+pub use psu_toml_viewer::*;
 pub use tab::*;
 pub use title_cfg_viewer::*;

--- a/crates/suitcase/src/tabs/psu_toml_viewer.rs
+++ b/crates/suitcase/src/tabs/psu_toml_viewer.rs
@@ -1,0 +1,272 @@
+use crate::data::state::AppState;
+use crate::tabs::Tab;
+use crate::VirtualFile;
+use eframe::egui::{self, menu, Color32, DragValue, ScrollArea, TextEdit, Ui};
+use relative_path::PathExt;
+use std::path::PathBuf;
+use toml::value::Table;
+use toml::Value;
+
+pub struct PsuTomlViewer {
+    file: String,
+    file_path: PathBuf,
+    contents: String,
+    structured: Option<Value>,
+    parse_error: Option<String>,
+    show_raw: bool,
+    modified: bool,
+}
+
+impl PsuTomlViewer {
+    pub fn new(file: &VirtualFile, state: &AppState) -> Self {
+        let contents = std::fs::read_to_string(&file.file_path).unwrap_or_default();
+        let file_path = file.file_path.clone();
+        let file = file
+            .file_path
+            .relative_to(state.opened_folder.clone().unwrap())
+            .unwrap()
+            .to_string();
+
+        Self {
+            file,
+            file_path,
+            contents,
+            structured: None,
+            parse_error: None,
+            show_raw: true,
+            modified: false,
+        }
+    }
+
+    pub fn show(&mut self, ui: &mut Ui) {
+        ui.vertical(|ui| {
+            menu::bar(ui, |ui| {
+                ui.set_height(25.0);
+                if ui.button("Save").clicked() {
+                    self.save();
+                }
+                let toggle_label = if self.show_raw {
+                    "Structured View"
+                } else {
+                    "Raw View"
+                };
+                if ui.button(toggle_label).clicked() {
+                    self.toggle_view();
+                }
+            });
+
+            if let Some(error) = &self.parse_error {
+                ui.colored_label(Color32::RED, format!("Failed to parse TOML: {error}"));
+            }
+
+            ui.separator();
+
+            ScrollArea::vertical().show(ui, |ui| {
+                if self.show_raw {
+                    self.show_raw_editor(ui);
+                } else {
+                    self.show_structured_editor(ui);
+                }
+            });
+        });
+    }
+
+    fn show_raw_editor(&mut self, ui: &mut Ui) {
+        let response = ui.add(
+            TextEdit::multiline(&mut self.contents)
+                .desired_width(ui.available_width())
+                .code_editor(),
+        );
+
+        if response.changed() {
+            self.modified = true;
+            self.structured = None;
+            self.parse_error = None;
+        }
+    }
+
+    fn show_structured_editor(&mut self, ui: &mut Ui) {
+        if let Some(value) = &mut self.structured {
+            let changed = match value {
+                Value::Table(table) => Self::render_table(ui, "", table),
+                Value::Array(array) => Self::render_array(ui, "", array),
+                _ => Self::render_entry(ui, "", "value", value),
+            };
+
+            if changed {
+                self.modified = true;
+                self.contents = Self::value_to_string(value);
+            }
+        } else {
+            ui.label("Switch back to the raw editor to resolve parsing issues.");
+        }
+    }
+
+    fn toggle_view(&mut self) {
+        if self.show_raw {
+            match self.parse_contents() {
+                Ok(value) => {
+                    self.structured = Some(value);
+                    self.parse_error = None;
+                    self.show_raw = false;
+                }
+                Err(err) => {
+                    self.parse_error = Some(err);
+                }
+            }
+        } else {
+            if let Some(value) = &self.structured {
+                self.contents = Self::value_to_string(value);
+            }
+            self.show_raw = true;
+            self.structured = None;
+            self.parse_error = None;
+        }
+    }
+
+    fn parse_contents(&self) -> Result<Value, String> {
+        self.contents
+            .parse::<Value>()
+            .map_err(|err| err.to_string())
+    }
+
+    fn render_table(ui: &mut Ui, path: &str, table: &mut Table) -> bool {
+        let mut changed = false;
+        for (key, value) in table.iter_mut() {
+            let child_path = Self::join_path(path, key);
+            if Self::render_entry(ui, &child_path, key, value) {
+                changed = true;
+            }
+        }
+        changed
+    }
+
+    fn render_array(ui: &mut Ui, path: &str, array: &mut Vec<Value>) -> bool {
+        let mut changed = false;
+        for (index, value) in array.iter_mut().enumerate() {
+            let label = format!("[{index}]");
+            let child_path = Self::join_index(path, index);
+            if Self::render_entry(ui, &child_path, &label, value) {
+                changed = true;
+            }
+        }
+        changed
+    }
+
+    fn render_entry(ui: &mut Ui, path: &str, label: &str, value: &mut Value) -> bool {
+        match value {
+            Value::Table(table) => egui::CollapsingHeader::new(label)
+                .id_source(path.to_owned())
+                .default_open(true)
+                .show(ui, |ui| Self::render_table(ui, path, table))
+                .inner
+                .unwrap_or(false),
+            Value::Array(array) => egui::CollapsingHeader::new(label)
+                .id_source(path.to_owned())
+                .default_open(true)
+                .show(ui, |ui| Self::render_array(ui, path, array))
+                .inner
+                .unwrap_or(false),
+            Value::String(text) => {
+                ui.horizontal(|ui| {
+                    ui.label(label);
+                    ui.text_edit_singleline(text).changed()
+                })
+                .inner
+            }
+            Value::Integer(integer) => {
+                ui.horizontal(|ui| {
+                    ui.label(label);
+                    let mut value = *integer;
+                    let changed = ui.add(DragValue::new(&mut value)).changed();
+                    if changed {
+                        *integer = value;
+                    }
+                    changed
+                })
+                .inner
+            }
+            Value::Float(float) => {
+                ui.horizontal(|ui| {
+                    ui.label(label);
+                    let mut value = *float;
+                    let changed = ui.add(DragValue::new(&mut value).speed(0.1)).changed();
+                    if changed {
+                        *float = value;
+                    }
+                    changed
+                })
+                .inner
+            }
+            Value::Boolean(boolean) => ui.checkbox(boolean, label).changed(),
+            Value::Datetime(datetime) => {
+                ui.horizontal(|ui| {
+                    ui.label(label);
+                    let mut text = datetime.to_string();
+                    let response = ui.text_edit_singleline(&mut text);
+                    if response.changed() {
+                        match text.parse() {
+                            Ok(parsed) => {
+                                *datetime = parsed;
+                                true
+                            }
+                            Err(_) => {
+                                ui.colored_label(Color32::RED, "Invalid datetime");
+                                false
+                            }
+                        }
+                    } else {
+                        false
+                    }
+                })
+                .inner
+            }
+        }
+    }
+
+    fn join_path(path: &str, segment: &str) -> String {
+        if path.is_empty() {
+            segment.to_owned()
+        } else {
+            format!("{path}.{segment}")
+        }
+    }
+
+    fn join_index(path: &str, index: usize) -> String {
+        if path.is_empty() {
+            format!("[{index}]")
+        } else {
+            format!("{path}[{index}]")
+        }
+    }
+
+    fn value_to_string(value: &Value) -> String {
+        toml::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+    }
+}
+
+impl Tab for PsuTomlViewer {
+    fn get_id(&self) -> &str {
+        &self.file
+    }
+
+    fn get_title(&self) -> String {
+        self.file.clone()
+    }
+
+    fn get_modified(&self) -> bool {
+        self.modified
+    }
+
+    fn save(&mut self) {
+        if !self.show_raw {
+            if let Some(value) = &self.structured {
+                self.contents = Self::value_to_string(value);
+            }
+        }
+
+        std::fs::write(&self.file_path, self.contents.as_bytes())
+            .expect("Failed to write psu.toml");
+        self.modified = false;
+    }
+}


### PR DESCRIPTION
## Summary
- add a PSU TOML viewer tab with raw/structured editing modes, save support, and scrollable layout
- register the PSU TOML viewer module and expose it through the tab system
- open .toml files in the suitcase UI using the new PSU TOML viewer

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68c986ed3294832191a77aaaeea11459