### PR TITLE
Fix Shift-JIS newline decoding

### DIFF
--- a/crates/ps2-filetypes/src/common/sjis.rs
+++ b/crates/ps2-filetypes/src/common/sjis.rs
@@ -20,46 +20,70 @@ pub fn encode_sjis(input: &str) -> Vec<u8> {
 }
 
 pub fn decode_sjis(input: &[u8]) -> String {
-    let mut str_out = vec![0u8; input.len()];
+    let mut str_out = Vec::with_capacity(input.len());
 
-    for (i, pair) in input.chunks_exact(2).enumerate() {
-        str_out[i] = match pair[0] {
+    for pair in input.chunks_exact(2) {
+        match pair[0] {
             0x00 => {
                 if pair[1] == 0x00 {
-                    b'\0'
+                    str_out.push(b'\0');
                 } else {
-                    b'?'
+                    str_out.push(b'?');
                 }
             }
-            0x0D => {
-                if pair[1] == 0x0A {
-                    // TODO: Technically this should be \r\n, but for now it works
-                    b'\n'
-                } else {
-                    b'?'
-                }
-            }
+            0x0D => match pair[1] {
+                0x0A => str_out.extend_from_slice(b"\r\n"),
+                0x00 => str_out.push(b'\r'),
+                _ => str_out.push(b'?'),
+            },
+            0x0A => match pair[1] {
+                0x00 => str_out.push(b'\n'),
+                _ => str_out.push(b'?'),
+            },
             0x81 => match pair[1] {
-                0x40 => b' ',
-                0x46 => b':',
-                0x5E => b'/',
-                0x69 => b'(',
-                0x6A => b')',
-                0x6D => b'[',
-                0x6E => b']',
-                0x6F => b'{',
-                0x70 => b'}',
-                _ => b'?',
+                0x40 => str_out.push(b' '),
+                0x46 => str_out.push(b':'),
+                0x5E => str_out.push(b'/'),
+                0x69 => str_out.push(b'('),
+                0x6A => str_out.push(b')'),
+                0x6D => str_out.push(b'['),
+                0x6E => str_out.push(b']'),
+                0x6F => str_out.push(b'{'),
+                0x70 => str_out.push(b'}'),
+                _ => str_out.push(b'?'),
             },
             0x82 => match pair[1] {
-                0x4f..=0x7A => pair[1] - 31,
-                0x81..=0x99 => pair[1] - 32,
-                0x3F => b' ',
-                _ => b'?',
+                0x4f..=0x7A => str_out.push(pair[1] - 31),
+                0x81..=0x99 => str_out.push(pair[1] - 32),
+                0x3F => str_out.push(b' '),
+                _ => str_out.push(b'?'),
             },
-            _ => b'?',
+            _ => str_out.push(b'?'),
         };
     }
 
     String::from_utf8_lossy(&str_out).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_crlf_preserves_both_characters() {
+        let input = [0x0D, 0x0A];
+        assert_eq!(decode_sjis(&input), "\r\n");
+    }
+
+    #[test]
+    fn decode_cr_only() {
+        let input = [0x0D, 0x00];
+        assert_eq!(decode_sjis(&input), "\r");
+    }
+
+    #[test]
+    fn decode_lf_only() {
+        let input = [0x0A, 0x00];
+        assert_eq!(decode_sjis(&input), "\n");
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `decode_sjis` outputs CRLF as ``"\r\n"`` while still decoding lone CR and LF bytes
- add unit tests covering CRLF, CR-only, and LF-only decoding paths

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c9af5fff5083219e4a6b0cc935164e