### PR TITLE
Add icon.sys editor tab and presets

### DIFF
--- a/crates/psu-packer-gui/src/ui/file_picker.rs
+++ b/crates/psu-packer-gui/src/ui/file_picker.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use eframe::egui;
 use ps2_filetypes::{PSUEntryKind, PSU};
 
-use crate::{IconFlagSelection, PackerApp, ICON_SYS_FLAG_OPTIONS};
+use crate::PackerApp;
 
 pub(crate) fn file_menu(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.menu_button("File", |ui| {
@@ -25,6 +25,11 @@ pub(crate) fn file_menu(app: &mut PackerApp, ui: &mut egui::Ui) {
 
             if ui.button("Edit title.cfg").clicked() {
                 app.open_title_cfg_tab();
+                ui.close_menu();
+            }
+
+            if ui.button("Edit icon.sys").clicked() {
+                app.open_icon_sys_tab();
                 ui.close_menu();
             }
 
@@ -77,19 +82,7 @@ pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
                             app.selected_include = None;
                             app.selected_exclude = None;
                             if let Some(icon_cfg) = icon_sys {
-                                let psu_packer::IconSysConfig { flags, title, .. } = icon_cfg;
-                                let flag_value = flags.value();
-                                app.icon_sys_enabled = true;
-                                app.icon_sys_title = title;
-                                app.icon_sys_custom_flag = flag_value;
-                                if let Some(index) = ICON_SYS_FLAG_OPTIONS
-                                    .iter()
-                                    .position(|(value, _)| *value == flag_value)
-                                {
-                                    app.icon_sys_flag_selection = IconFlagSelection::Preset(index);
-                                } else {
-                                    app.icon_sys_flag_selection = IconFlagSelection::Custom;
-                                }
+                                app.apply_icon_sys_config(icon_cfg);
                             } else {
                                 app.reset_icon_sys_fields();
                             }
@@ -113,7 +106,11 @@ pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
                     app.loaded_psu_files.clear();
                     app.folder = Some(folder.clone());
                     app.reload_project_files();
-                    app.open_psu_settings_tab();
+                    if app.icon_sys_enabled {
+                        app.open_icon_sys_tab();
+                    } else {
+                        app.open_psu_settings_tab();
+                    }
                 }
             }
         });

--- a/crates/psu-packer-gui/src/ui/icon_sys.rs
+++ b/crates/psu-packer-gui/src/ui/icon_sys.rs
@@ -1,0 +1,531 @@
+use eframe::egui::{self, Color32};
+
+use crate::{IconFlagSelection, PackerApp, ICON_SYS_FLAG_OPTIONS};
+use psu_packer::{ColorConfig, ColorFConfig, IconSysConfig, VectorConfig};
+
+const TITLE_CHAR_LIMIT: usize = 10;
+
+#[derive(Clone, Copy)]
+struct IconSysPreset {
+    id: &'static str,
+    label: &'static str,
+    background_transparency: u32,
+    background_colors: [ColorConfig; 4],
+    light_directions: [VectorConfig; 3],
+    light_colors: [ColorFConfig; 3],
+    ambient_color: ColorFConfig,
+}
+
+const ICON_SYS_PRESETS: &[IconSysPreset] = &[
+    IconSysPreset {
+        id: "default",
+        label: "Standard (PS2)",
+        background_transparency: IconSysConfig::default_background_transparency(),
+        background_colors: IconSysConfig::default_background_colors(),
+        light_directions: IconSysConfig::default_light_directions(),
+        light_colors: IconSysConfig::default_light_colors(),
+        ambient_color: IconSysConfig::default_ambient_color(),
+    },
+    IconSysPreset {
+        id: "cool_blue",
+        label: "Cool Blue",
+        background_transparency: 0,
+        background_colors: [
+            ColorConfig {
+                r: 0,
+                g: 32,
+                b: 96,
+                a: 0,
+            },
+            ColorConfig {
+                r: 0,
+                g: 48,
+                b: 128,
+                a: 0,
+            },
+            ColorConfig {
+                r: 0,
+                g: 64,
+                b: 160,
+                a: 0,
+            },
+            ColorConfig {
+                r: 0,
+                g: 16,
+                b: 48,
+                a: 0,
+            },
+        ],
+        light_directions: [
+            VectorConfig {
+                x: 0.0,
+                y: 0.0,
+                z: 1.0,
+                w: 0.0,
+            },
+            VectorConfig {
+                x: -0.5,
+                y: -0.5,
+                z: 0.5,
+                w: 0.0,
+            },
+            VectorConfig {
+                x: 0.5,
+                y: -0.5,
+                z: 0.5,
+                w: 0.0,
+            },
+        ],
+        light_colors: [
+            ColorFConfig {
+                r: 1.0,
+                g: 1.0,
+                b: 1.0,
+                a: 1.0,
+            },
+            ColorFConfig {
+                r: 0.5,
+                g: 0.5,
+                b: 0.6,
+                a: 1.0,
+            },
+            ColorFConfig {
+                r: 0.3,
+                g: 0.3,
+                b: 0.4,
+                a: 1.0,
+            },
+        ],
+        ambient_color: ColorFConfig {
+            r: 0.2,
+            g: 0.2,
+            b: 0.2,
+            a: 1.0,
+        },
+    },
+    IconSysPreset {
+        id: "warm_sunset",
+        label: "Warm Sunset",
+        background_transparency: 0,
+        background_colors: [
+            ColorConfig {
+                r: 128,
+                g: 48,
+                b: 16,
+                a: 0,
+            },
+            ColorConfig {
+                r: 176,
+                g: 72,
+                b: 32,
+                a: 0,
+            },
+            ColorConfig {
+                r: 208,
+                g: 112,
+                b: 48,
+                a: 0,
+            },
+            ColorConfig {
+                r: 96,
+                g: 32,
+                b: 16,
+                a: 0,
+            },
+        ],
+        light_directions: [
+            VectorConfig {
+                x: -0.2,
+                y: -0.4,
+                z: 0.8,
+                w: 0.0,
+            },
+            VectorConfig {
+                x: 0.0,
+                y: -0.6,
+                z: 0.6,
+                w: 0.0,
+            },
+            VectorConfig {
+                x: 0.3,
+                y: -0.5,
+                z: 0.7,
+                w: 0.0,
+            },
+        ],
+        light_colors: [
+            ColorFConfig {
+                r: 1.0,
+                g: 0.9,
+                b: 0.75,
+                a: 1.0,
+            },
+            ColorFConfig {
+                r: 0.9,
+                g: 0.6,
+                b: 0.3,
+                a: 1.0,
+            },
+            ColorFConfig {
+                r: 0.6,
+                g: 0.3,
+                b: 0.2,
+                a: 1.0,
+            },
+        ],
+        ambient_color: ColorFConfig {
+            r: 0.25,
+            g: 0.18,
+            b: 0.12,
+            a: 1.0,
+        },
+    },
+];
+
+pub(crate) fn icon_sys_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
+    ui.heading("icon.sys metadata");
+    ui.small("Configure the save icon title, flags, and lighting.");
+    ui.add_space(8.0);
+
+    let checkbox = ui.checkbox(&mut app.icon_sys_enabled, "Generate icon.sys metadata");
+    checkbox.on_hover_text("Automatically creates or updates icon.sys when packing the PSU.");
+
+    ui.add_space(8.0);
+
+    ui.add_enabled_ui(app.icon_sys_enabled, |ui| {
+        title_section(app, ui);
+        ui.add_space(12.0);
+        flag_section(app, ui);
+        ui.add_space(12.0);
+        presets_section(app, ui);
+        ui.add_space(12.0);
+        background_section(app, ui);
+        ui.add_space(12.0);
+        lighting_section(app, ui);
+    });
+}
+
+fn title_section(app: &mut PackerApp, ui: &mut egui::Ui) {
+    ui.group(|ui| {
+        ui.heading("Title");
+        ui.small("Each line supports up to 10 ASCII characters.");
+        ui.add_space(4.0);
+
+        egui::Grid::new("icon_sys_title_grid")
+            .num_columns(2)
+            .spacing(egui::vec2(8.0, 4.0))
+            .show(ui, |ui| {
+                ui.label("Line 1");
+                title_input(
+                    ui,
+                    egui::Id::new("icon_sys_title_line1"),
+                    &mut app.icon_sys_title_line1,
+                );
+                ui.end_row();
+
+                ui.label("Line 2");
+                title_input(
+                    ui,
+                    egui::Id::new("icon_sys_title_line2"),
+                    &mut app.icon_sys_title_line2,
+                );
+                ui.end_row();
+
+                ui.label("Preview");
+                ui.vertical(|ui| {
+                    ui.monospace(format!("{:<10}", app.icon_sys_title_line1));
+                    ui.monospace(format!("{:<10}", app.icon_sys_title_line2));
+                    let break_pos = app.icon_sys_title_line1.chars().count();
+                    ui.small(format!("Line break position: {break_pos}"));
+                });
+                ui.end_row();
+            });
+    });
+}
+
+fn title_input(ui: &mut egui::Ui, id: egui::Id, value: &mut String) {
+    let mut edit = egui::TextEdit::singleline(value)
+        .char_limit(TITLE_CHAR_LIMIT)
+        .desired_width(120.0);
+    edit = edit.id_source(id);
+
+    let response = ui.add(edit);
+    if response.changed() {
+        let mut sanitized = value
+            .chars()
+            .filter(|c| c.is_ascii() && !c.is_control())
+            .collect::<String>();
+        if sanitized.len() > TITLE_CHAR_LIMIT {
+            sanitized.truncate(TITLE_CHAR_LIMIT);
+        }
+        if *value != sanitized {
+            *value = sanitized;
+        }
+    }
+
+    ui.small(format!("{} / {TITLE_CHAR_LIMIT}", value.chars().count()));
+}
+
+fn flag_section(app: &mut PackerApp, ui: &mut egui::Ui) {
+    ui.group(|ui| {
+        ui.heading("Flags");
+        ui.add_space(4.0);
+        egui::Grid::new("icon_sys_flag_grid")
+            .num_columns(2)
+            .spacing(egui::vec2(8.0, 4.0))
+            .show(ui, |ui| {
+                ui.label("Icon type");
+                ui.horizontal(|ui| {
+                    egui::ComboBox::from_id_source("icon_sys_flag_combo")
+                        .selected_text(app.icon_flag_label())
+                        .show_ui(ui, |ui| {
+                            for (idx, (_, label)) in ICON_SYS_FLAG_OPTIONS.iter().enumerate() {
+                                ui.selectable_value(
+                                    &mut app.icon_sys_flag_selection,
+                                    IconFlagSelection::Preset(idx),
+                                    *label,
+                                );
+                            }
+                            ui.selectable_value(
+                                &mut app.icon_sys_flag_selection,
+                                IconFlagSelection::Custom,
+                                "Custom…",
+                            );
+                        });
+
+                    if matches!(app.icon_sys_flag_selection, IconFlagSelection::Custom) {
+                        let response = ui.add(
+                            egui::DragValue::new(&mut app.icon_sys_custom_flag)
+                                .clamp_range(0.0..=u16::MAX as f64)
+                                .speed(1),
+                        );
+                        response.on_hover_text("Enter the raw flag value (0-65535).");
+                        ui.label(format!("0x{:04X}", app.icon_sys_custom_flag));
+                    }
+                });
+                ui.end_row();
+            });
+    });
+}
+
+fn presets_section(app: &mut PackerApp, ui: &mut egui::Ui) {
+    ui.group(|ui| {
+        ui.heading("Presets");
+        ui.small("Choose a preset to populate the colors and lights automatically.");
+        ui.add_space(4.0);
+
+        let selected_label = match app.icon_sys_selected_preset.as_deref() {
+            Some(id) => find_preset(id)
+                .map(|preset| preset.label.to_string())
+                .unwrap_or_else(|| format!("Custom ({id})")),
+            None => "Manual".to_string(),
+        };
+
+        egui::ComboBox::from_id_source("icon_sys_preset_combo")
+            .selected_text(selected_label)
+            .show_ui(ui, |ui| {
+                if ui
+                    .selectable_label(app.icon_sys_selected_preset.is_none(), "Manual")
+                    .clicked()
+                {
+                    app.clear_icon_sys_preset();
+                }
+                for preset in ICON_SYS_PRESETS {
+                    let selected = app
+                        .icon_sys_selected_preset
+                        .as_deref()
+                        .map(|id| id == preset.id)
+                        .unwrap_or(false);
+                    if ui.selectable_label(selected, preset.label).clicked() {
+                        apply_preset(app, preset);
+                    }
+                }
+            });
+
+        ui.add_space(6.0);
+        preset_preview(app, ui);
+    });
+}
+
+fn preset_preview(app: &PackerApp, ui: &mut egui::Ui) {
+    ui.vertical(|ui| {
+        ui.label("Background gradient");
+        ui.horizontal(|ui| {
+            for color in app.icon_sys_background_colors {
+                draw_color_swatch(ui, color32_from_color_config(color));
+            }
+        });
+
+        ui.label("Light colors");
+        ui.horizontal(|ui| {
+            for color in app.icon_sys_light_colors {
+                draw_color_swatch(ui, color32_from_color_f_config(color));
+            }
+        });
+
+        ui.label("Ambient");
+        draw_color_swatch(ui, color32_from_color_f_config(app.icon_sys_ambient_color));
+    });
+}
+
+fn draw_color_swatch(ui: &mut egui::Ui, color: Color32) {
+    let (rect, _) = ui.allocate_exact_size(egui::vec2(20.0, 14.0), egui::Sense::hover());
+    ui.painter().rect_filled(rect, 3.0, color);
+}
+
+fn background_section(app: &mut PackerApp, ui: &mut egui::Ui) {
+    ui.group(|ui| {
+        ui.heading("Background");
+        ui.small("Adjust the gradient colors and alpha layer.");
+        ui.add_space(4.0);
+
+        if ui
+            .add(
+                egui::DragValue::new(&mut app.icon_sys_background_transparency)
+                    .clamp_range(0.0..=255.0)
+                    .speed(1)
+                    .suffix(" α"),
+            )
+            .changed()
+        {
+            app.clear_icon_sys_preset();
+        }
+
+        ui.add_space(4.0);
+        let mut background_changed = false;
+        egui::Grid::new("icon_sys_background_grid")
+            .num_columns(2)
+            .spacing(egui::vec2(8.0, 4.0))
+            .show(ui, |ui| {
+                for (index, color) in app.icon_sys_background_colors.iter_mut().enumerate() {
+                    ui.label(format!("Color {}", index + 1));
+                    let mut display = color32_from_color_config(*color);
+                    if ui.color_edit_button_srgba(&mut display).changed() {
+                        *color = color_config_from_color32(display);
+                        background_changed = true;
+                    }
+                    ui.end_row();
+                }
+            });
+        if background_changed {
+            app.clear_icon_sys_preset();
+        }
+    });
+}
+
+fn lighting_section(app: &mut PackerApp, ui: &mut egui::Ui) {
+    ui.group(|ui| {
+        ui.heading("Lighting");
+        ui.small("Tweak light directions, colors, and the ambient glow.");
+        ui.add_space(4.0);
+
+        let mut lighting_changed = false;
+
+        for (index, (color, direction)) in app
+            .icon_sys_light_colors
+            .iter_mut()
+            .zip(app.icon_sys_light_directions.iter_mut())
+            .enumerate()
+        {
+            let mut light_dirty = false;
+            ui.collapsing(format!("Light {}", index + 1), |ui| {
+                ui.label("Color");
+                let mut rgba = color_f_config_to_array(*color);
+                if ui.color_edit_button_rgba_unmultiplied(&mut rgba).changed() {
+                    *color = array_to_color_f_config(rgba);
+                    light_dirty = true;
+                }
+
+                ui.add_space(4.0);
+                ui.label("Direction");
+                for (label, component) in [
+                    ("x", &mut direction.x),
+                    ("y", &mut direction.y),
+                    ("z", &mut direction.z),
+                    ("w", &mut direction.w),
+                ] {
+                    ui.horizontal(|ui| {
+                        ui.label(label);
+                        if ui
+                            .add(
+                                egui::DragValue::new(component)
+                                    .clamp_range(-1.0..=1.0)
+                                    .speed(0.01),
+                            )
+                            .changed()
+                        {
+                            light_dirty = true;
+                        }
+                    });
+                }
+            });
+            if light_dirty {
+                lighting_changed = true;
+            }
+            ui.add_space(4.0);
+        }
+
+        ui.label("Ambient color");
+        let mut ambient = color_f_config_to_array(app.icon_sys_ambient_color);
+        if ui
+            .color_edit_button_rgba_unmultiplied(&mut ambient)
+            .changed()
+        {
+            app.icon_sys_ambient_color = array_to_color_f_config(ambient);
+            lighting_changed = true;
+        }
+
+        if lighting_changed {
+            app.clear_icon_sys_preset();
+        }
+    });
+}
+
+fn apply_preset(app: &mut PackerApp, preset: &IconSysPreset) {
+    app.icon_sys_background_transparency = preset.background_transparency;
+    app.icon_sys_background_colors = preset.background_colors;
+    app.icon_sys_light_directions = preset.light_directions;
+    app.icon_sys_light_colors = preset.light_colors;
+    app.icon_sys_ambient_color = preset.ambient_color;
+    app.icon_sys_selected_preset = Some(preset.id.to_string());
+}
+
+fn find_preset(id: &str) -> Option<&'static IconSysPreset> {
+    ICON_SYS_PRESETS.iter().find(|preset| preset.id == id)
+}
+
+fn color32_from_color_config(color: ColorConfig) -> Color32 {
+    Color32::from_rgba_unmultiplied(color.r, color.g, color.b, color.a)
+}
+
+fn color32_from_color_f_config(color: ColorFConfig) -> Color32 {
+    let clamp = |value: f32| -> u8 { (value.clamp(0.0, 1.0) * 255.0).round() as u8 };
+    Color32::from_rgba_unmultiplied(
+        clamp(color.r),
+        clamp(color.g),
+        clamp(color.b),
+        clamp(color.a),
+    )
+}
+
+fn color_config_from_color32(color: Color32) -> ColorConfig {
+    ColorConfig {
+        r: color.r(),
+        g: color.g(),
+        b: color.b(),
+        a: color.a(),
+    }
+}
+
+fn color_f_config_to_array(color: ColorFConfig) -> [f32; 4] {
+    [color.r, color.g, color.b, color.a]
+}
+
+fn array_to_color_f_config(color: [f32; 4]) -> ColorFConfig {
+    ColorFConfig {
+        r: color[0],
+        g: color[1],
+        b: color[2],
+        a: color[3],
+    }
+}

--- a/crates/psu-packer-gui/src/ui/mod.rs
+++ b/crates/psu-packer-gui/src/ui/mod.rs
@@ -1,3 +1,4 @@
 pub mod dialogs;
 pub mod file_picker;
+pub mod icon_sys;
 pub mod pack_controls;

--- a/crates/psu-packer/src/lib.rs
+++ b/crates/psu-packer/src/lib.rs
@@ -67,10 +67,14 @@ impl From<ConfigFile> for Config {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct IconSysConfig {
     pub flags: IconSysFlags,
     pub title: String,
+    #[serde(default)]
+    pub linebreak_pos: Option<u16>,
+    #[serde(default)]
+    pub preset: Option<String>,
     #[serde(default)]
     pub background_transparency: Option<u32>,
     #[serde(default)]
@@ -143,9 +147,11 @@ impl IconSysConfig {
             .background_transparency
             .unwrap_or(DEFAULT_BACKGROUND_TRANSPARENCY);
 
+        let linebreak_pos = self.linebreak_pos.unwrap_or(DEFAULT_LINEBREAK_POS);
+
         Ok(IconSys {
             flags: self.flags.value(),
-            linebreak_pos: DEFAULT_LINEBREAK_POS,
+            linebreak_pos,
             background_transparency,
             background_colors,
             light_directions,
@@ -156,6 +162,144 @@ impl IconSysConfig {
             icon_copy_file: ICON_FILE_NAME.to_string(),
             icon_delete_file: ICON_FILE_NAME.to_string(),
         })
+    }
+}
+
+impl IconSysConfig {
+    pub const fn default_linebreak_pos() -> u16 {
+        DEFAULT_LINEBREAK_POS
+    }
+
+    pub const fn default_background_transparency() -> u32 {
+        DEFAULT_BACKGROUND_TRANSPARENCY
+    }
+
+    pub const fn default_background_colors() -> [ColorConfig; 4] {
+        [
+            ColorConfig {
+                r: DEFAULT_BACKGROUND_COLORS[0].r,
+                g: DEFAULT_BACKGROUND_COLORS[0].g,
+                b: DEFAULT_BACKGROUND_COLORS[0].b,
+                a: DEFAULT_BACKGROUND_COLORS[0].a,
+            },
+            ColorConfig {
+                r: DEFAULT_BACKGROUND_COLORS[1].r,
+                g: DEFAULT_BACKGROUND_COLORS[1].g,
+                b: DEFAULT_BACKGROUND_COLORS[1].b,
+                a: DEFAULT_BACKGROUND_COLORS[1].a,
+            },
+            ColorConfig {
+                r: DEFAULT_BACKGROUND_COLORS[2].r,
+                g: DEFAULT_BACKGROUND_COLORS[2].g,
+                b: DEFAULT_BACKGROUND_COLORS[2].b,
+                a: DEFAULT_BACKGROUND_COLORS[2].a,
+            },
+            ColorConfig {
+                r: DEFAULT_BACKGROUND_COLORS[3].r,
+                g: DEFAULT_BACKGROUND_COLORS[3].g,
+                b: DEFAULT_BACKGROUND_COLORS[3].b,
+                a: DEFAULT_BACKGROUND_COLORS[3].a,
+            },
+        ]
+    }
+
+    pub const fn default_light_directions() -> [VectorConfig; 3] {
+        [
+            VectorConfig {
+                x: DEFAULT_LIGHT_DIRECTIONS[0].x,
+                y: DEFAULT_LIGHT_DIRECTIONS[0].y,
+                z: DEFAULT_LIGHT_DIRECTIONS[0].z,
+                w: DEFAULT_LIGHT_DIRECTIONS[0].w,
+            },
+            VectorConfig {
+                x: DEFAULT_LIGHT_DIRECTIONS[1].x,
+                y: DEFAULT_LIGHT_DIRECTIONS[1].y,
+                z: DEFAULT_LIGHT_DIRECTIONS[1].z,
+                w: DEFAULT_LIGHT_DIRECTIONS[1].w,
+            },
+            VectorConfig {
+                x: DEFAULT_LIGHT_DIRECTIONS[2].x,
+                y: DEFAULT_LIGHT_DIRECTIONS[2].y,
+                z: DEFAULT_LIGHT_DIRECTIONS[2].z,
+                w: DEFAULT_LIGHT_DIRECTIONS[2].w,
+            },
+        ]
+    }
+
+    pub const fn default_light_colors() -> [ColorFConfig; 3] {
+        [
+            ColorFConfig {
+                r: DEFAULT_LIGHT_COLORS[0].r,
+                g: DEFAULT_LIGHT_COLORS[0].g,
+                b: DEFAULT_LIGHT_COLORS[0].b,
+                a: DEFAULT_LIGHT_COLORS[0].a,
+            },
+            ColorFConfig {
+                r: DEFAULT_LIGHT_COLORS[1].r,
+                g: DEFAULT_LIGHT_COLORS[1].g,
+                b: DEFAULT_LIGHT_COLORS[1].b,
+                a: DEFAULT_LIGHT_COLORS[1].a,
+            },
+            ColorFConfig {
+                r: DEFAULT_LIGHT_COLORS[2].r,
+                g: DEFAULT_LIGHT_COLORS[2].g,
+                b: DEFAULT_LIGHT_COLORS[2].b,
+                a: DEFAULT_LIGHT_COLORS[2].a,
+            },
+        ]
+    }
+
+    pub const fn default_ambient_color() -> ColorFConfig {
+        ColorFConfig {
+            r: DEFAULT_AMBIENT_COLOR.r,
+            g: DEFAULT_AMBIENT_COLOR.g,
+            b: DEFAULT_AMBIENT_COLOR.b,
+            a: DEFAULT_AMBIENT_COLOR.a,
+        }
+    }
+
+    pub fn background_transparency_value(&self) -> u32 {
+        self.background_transparency
+            .unwrap_or(Self::default_background_transparency())
+    }
+
+    pub fn background_colors_array(&self) -> [ColorConfig; 4] {
+        let mut colors = Self::default_background_colors();
+        if let Some(values) = &self.background_colors {
+            for (target, value) in colors.iter_mut().zip(values.iter()) {
+                *target = *value;
+            }
+        }
+        colors
+    }
+
+    pub fn light_directions_array(&self) -> [VectorConfig; 3] {
+        let mut directions = Self::default_light_directions();
+        if let Some(values) = &self.light_directions {
+            for (target, value) in directions.iter_mut().zip(values.iter()) {
+                *target = *value;
+            }
+        }
+        directions
+    }
+
+    pub fn light_colors_array(&self) -> [ColorFConfig; 3] {
+        let mut colors = Self::default_light_colors();
+        if let Some(values) = &self.light_colors {
+            for (target, value) in colors.iter_mut().zip(values.iter()) {
+                *target = *value;
+            }
+        }
+        colors
+    }
+
+    pub fn ambient_color_value(&self) -> ColorFConfig {
+        self.ambient_color
+            .unwrap_or_else(Self::default_ambient_color)
+    }
+
+    pub fn linebreak_position(&self) -> u16 {
+        self.linebreak_pos.unwrap_or(Self::default_linebreak_pos())
     }
 }
 


### PR DESCRIPTION
## Summary
- Added an icon.sys editor tab with title inputs, flag selection, preset previews, and manual color/light editing so the GUI can visualize icon metadata changes.【F:crates/psu-packer-gui/src/ui/icon_sys.rs†L1-L400】
- Extended the app state, file menu, and folder workflow to populate icon.sys data, remember presets, and automatically surface the new tab when a project enables icon.sys generation.【F:crates/psu-packer-gui/src/lib.rs†L100-L199】【F:crates/psu-packer-gui/src/lib.rs†L375-L733】【F:crates/psu-packer-gui/src/ui/file_picker.rs†L1-L119】
- Validated two-line ASCII titles and now serialize icon.sys colors, lights, transparency, line breaks, and preset identifiers through IconSysConfig for round-trip support.【F:crates/psu-packer-gui/src/ui/pack_controls.rs†L326-L367】【F:crates/psu-packer/src/lib.rs†L70-L303】

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68c9bb820fe88321a17541ee5b80b893