### PR TITLE
Configure GUI window size and centering

### DIFF
--- a/crates/psu-packer-gui/src/main.rs
+++ b/crates/psu-packer-gui/src/main.rs
@@ -1,9 +1,26 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use eframe::egui;
 use psu_packer_gui::PackerApp;
 
+trait NativeOptionsExt {
+    fn with_centered(self, centered: bool) -> Self;
+}
+
+impl NativeOptionsExt for eframe::NativeOptions {
+    fn with_centered(mut self, centered: bool) -> Self {
+        self.centered = centered;
+        self
+    }
+}
+
 fn main() -> eframe::Result<()> {
-    let options = eframe::NativeOptions::default();
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([1024.0, 768.0]),
+        ..Default::default()
+    }
+    .with_centered(true);
+
     eframe::run_native(
         "PSU Packer",
         options,


### PR DESCRIPTION
## Summary
- set the GUI's native options to use a fixed 1024x768 viewport size
- add a helper extension so the options can be marked as centered when building the window

## Testing
- cargo check -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68c9c3b284e88321b4e9eb3ca5aa40a2