### PR TITLE
Support reusing existing icon.sys files

### DIFF
--- a/crates/psu-packer-gui/src/ui/file_picker.rs
+++ b/crates/psu-packer-gui/src/ui/file_picker.rs
@@ -1,7 +1,7 @@
-use std::path::Path;
+use std::{fs, path::Path};
 
 use eframe::egui;
-use ps2_filetypes::{PSUEntryKind, PSU};
+use ps2_filetypes::{IconSys, PSUEntryKind, PSU};
 
 use crate::PackerApp;
 
@@ -81,13 +81,49 @@ pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
                             app.exclude_files = exclude.unwrap_or_default();
                             app.selected_include = None;
                             app.selected_exclude = None;
+                            app.clear_error_message();
+                            app.status.clear();
+
+                            let has_icon_sys_config = icon_sys.is_some();
                             if let Some(icon_cfg) = icon_sys {
                                 app.apply_icon_sys_config(icon_cfg);
                             } else {
                                 app.reset_icon_sys_fields();
                             }
-                            app.clear_error_message();
-                            app.status.clear();
+
+                            let icon_sys_path = folder.join("icon.sys");
+                            if icon_sys_path.is_file() {
+                                match fs::read(&icon_sys_path) {
+                                    Ok(bytes) => {
+                                        match std::panic::catch_unwind(|| IconSys::new(bytes)) {
+                                            Ok(parsed_icon_sys) => {
+                                                if has_icon_sys_config {
+                                                    app.icon_sys_existing = Some(parsed_icon_sys);
+                                                } else {
+                                                    app.apply_icon_sys_file(&parsed_icon_sys);
+                                                }
+                                            }
+                                            Err(_) => {
+                                                app.icon_sys_existing = None;
+                                                app.set_error_message(format!(
+                                                    "Failed to parse {} as an icon.sys file.",
+                                                    icon_sys_path.display()
+                                                ));
+                                            }
+                                        }
+                                    }
+                                    Err(err) => {
+                                        app.icon_sys_existing = None;
+                                        app.set_error_message(format!(
+                                            "Failed to read {}: {}",
+                                            icon_sys_path.display(),
+                                            err
+                                        ));
+                                    }
+                                }
+                            } else if has_icon_sys_config {
+                                app.icon_sys_existing = None;
+                            }
                         }
                         Err(err) => {
                             let message = format_load_error(&folder, err);

--- a/crates/psu-packer-gui/src/ui/icon_sys.rs
+++ b/crates/psu-packer-gui/src/ui/icon_sys.rs
@@ -187,12 +187,49 @@ pub(crate) fn icon_sys_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.small("Configure the save icon title, flags, and lighting.");
     ui.add_space(8.0);
 
-    let checkbox = ui.checkbox(&mut app.icon_sys_enabled, "Generate icon.sys metadata");
-    checkbox.on_hover_text("Automatically creates or updates icon.sys when packing the PSU.");
+    let checkbox = ui.checkbox(&mut app.icon_sys_enabled, "Enable icon.sys metadata");
+    checkbox
+        .on_hover_text("Use an existing icon.sys file or generate a new one when packing the PSU.");
+
+    if !app.icon_sys_enabled {
+        app.icon_sys_use_existing = false;
+    } else if app.icon_sys_existing.is_none() {
+        app.icon_sys_use_existing = false;
+    }
+
+    if app.icon_sys_enabled {
+        if let Some(existing_icon) = app.icon_sys_existing.clone() {
+            let previous = app.icon_sys_use_existing;
+            ui.horizontal(|ui| {
+                ui.label("Mode:");
+                ui.selectable_value(
+                    &mut app.icon_sys_use_existing,
+                    true,
+                    "Use existing icon.sys",
+                );
+                ui.selectable_value(
+                    &mut app.icon_sys_use_existing,
+                    false,
+                    "Generate new icon.sys",
+                );
+            });
+
+            if app.icon_sys_use_existing && !previous {
+                app.apply_icon_sys_file(&existing_icon);
+            }
+
+            if app.icon_sys_use_existing {
+                ui.small(concat!(
+                    "The existing icon.sys file will be packed without modification. ",
+                    "Switch to \"Generate new icon.sys\" to edit metadata.",
+                ));
+            }
+        }
+    }
 
     ui.add_space(8.0);
 
-    ui.add_enabled_ui(app.icon_sys_enabled, |ui| {
+    ui.add_enabled_ui(app.icon_sys_enabled && !app.icon_sys_use_existing, |ui| {
         title_section(app, ui);
         ui.add_space(12.0);
         flag_section(app, ui);


### PR DESCRIPTION
## Summary
- track parsed icon.sys files when opening a project folder so existing metadata can be reused
- add helper state on `PackerApp` to populate the editor from a parsed icon.sys and store the parsed data
- update the icon.sys editor and packing logic to toggle between reusing an existing file and generating a new one

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68c9cbcabbd48321893708e1b66db29a