### PR TITLE
Trim icon.sys flag options to supported presets

### DIFF
--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -16,12 +16,9 @@ pub use ui::{dialogs, file_picker, pack_controls};
 
 pub(crate) const TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S";
 pub(crate) const ICON_SYS_FLAG_OPTIONS: &[(u16, &str)] = &[
-    (0, "PS2 Save File"),
-    (1, "Software (PS2)"),
-    (2, "Unrecognized (0x02)"),
-    (3, "Software (Pocketstation)"),
-    (4, "Settings (PS2)"),
-    (5, "System Driver"),
+    (0, "Save Data"),
+    (1, "System Software"),
+    (4, "Settings"),
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- limit the icon.sys flag preset list to the supported Save Data, System Software, and Settings values
- retain the existing custom flag fallback so legacy configs with other values still select the Custom option

## Testing
- cargo check -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68c9de7d37ec8321bda139e447de5f95