### PR TITLE
Add deterministic timestamp explanation label

### DIFF
--- a/crates/psu-packer-gui/src/ui/timestamps.rs
+++ b/crates/psu-packer-gui/src/ui/timestamps.rs
@@ -20,6 +20,8 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
             manual_change = true;
         }
 
+        ui.small("Deterministic timestamps ensure repeated packs produce identical archives for verification.");
+
         if !has_timestamp {
             ui.small("No timestamp will be saved.");
             new_timestamp = None;


### PR DESCRIPTION
## Summary
- show a short explanation near the metadata timestamp controls so users know why deterministic timestamps exist

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68ca202a545883219aab49945df2c11a