### PR TITLE
Update suitcase icon handling

### DIFF
--- a/crates/suitcase/build.rs
+++ b/crates/suitcase/build.rs
@@ -7,7 +7,7 @@ fn main() -> io::Result<()> {
     if env::var_os("CARGO_CFG_WINDOWS").is_some() {
         WindowsResource::new()
             // This path can be absolute, or relative to your crate root.
-            .set_icon("assets/app_icon.ico")
+            .set_icon("assets/icon.ico")
             .compile()?;
     }
     Ok(())

--- a/crates/suitcase/src/main.rs
+++ b/crates/suitcase/src/main.rs
@@ -36,14 +36,13 @@ fn main() -> eframe::Result<()> {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([1920.0, 1080.0])
             .with_icon({
-                let icon = include_bytes!("../assets/app_icon.png");
-                let result = image::load_from_memory(icon).expect("Failed to load icon");
-
-                let width = result.width();
-                let height = result.height();
+                let icon = include_bytes!("../assets/icon.ico");
+                let image = image::load_from_memory(icon).expect("Failed to load icon");
+                let image = image.into_rgba8();
+                let (width, height) = image.dimensions();
 
                 IconData {
-                    rgba: result.as_rgba8().unwrap().clone().into_raw(),
+                    rgba: image.into_raw(),
                     width,
                     height,
                 }

--- a/crates/suitcase/src/tabs/psu_toml_viewer.rs
+++ b/crates/suitcase/src/tabs/psu_toml_viewer.rs
@@ -159,13 +159,13 @@ impl PsuTomlViewer {
                 .id_source(path.to_owned())
                 .default_open(true)
                 .show(ui, |ui| Self::render_table(ui, path, table))
-                .inner
+                .body_returned
                 .unwrap_or(false),
             Value::Array(array) => egui::CollapsingHeader::new(label)
                 .id_source(path.to_owned())
                 .default_open(true)
                 .show(ui, |ui| Self::render_array(ui, path, array))
-                .inner
+                .body_returned
                 .unwrap_or(false),
             Value::String(text) => {
                 ui.horizontal(|ui| {


### PR DESCRIPTION
## Summary
- load the suitcase viewport icon from the new ICO asset and convert it to RGBA bytes before constructing `IconData`
- point the Windows resource build script at the same ICO file for embedding
- adjust the PSU TOML viewer to use `CollapsingHeader::body_returned` so the crate still builds

## Testing
- cargo build -p suitcase

------
https://chatgpt.com/codex/tasks/task_e_68ca2c583d4c8321ad21151fffabc25a