### PR TITLE
Enable PSU text editing when archive is loaded

### DIFF
--- a/crates/psu-packer-gui/src/ui/pack_controls.rs
+++ b/crates/psu-packer-gui/src/ui/pack_controls.rs
@@ -212,6 +212,32 @@ impl ListKind {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    #[test]
+    fn build_config_uses_loaded_psu_edits() {
+        let mut app = PackerApp::default();
+        app.loaded_psu_path = Some(PathBuf::from("input.psu"));
+        app.selected_prefix = SasPrefix::Ps2;
+        app.folder_base_name = "SAVE".to_string();
+        let timestamp = NaiveDate::from_ymd_opt(2023, 11, 14)
+            .and_then(|date| date.and_hms_opt(12, 34, 56))
+            .expect("valid timestamp");
+        app.timestamp = Some(timestamp);
+        app.include_files.push("FILE.BIN".to_string());
+        app.exclude_files.push("SKIP.DAT".to_string());
+
+        let config = app.build_config().expect("config builds successfully");
+        assert_eq!(config.name, "PS2_SAVE");
+        assert_eq!(config.timestamp, Some(timestamp));
+        assert_eq!(config.include, Some(vec!["FILE.BIN".to_string()]));
+        assert_eq!(config.exclude, Some(vec!["SKIP.DAT".to_string()]));
+    }
+}
+
 fn file_list_ui(
     ui: &mut egui::Ui,
     label: &str,


### PR DESCRIPTION
## Summary
- enable psu.toml and title.cfg editors whenever a project folder or PSU archive is available
- keep disk saves gated on folder selection and update helper messaging for the new behavior
- add a regression test ensuring build_config respects metadata edits when a PSU is loaded

## Testing
- cargo test -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68ca39b6e8ec8321b64126f2e36e292a