### PR TITLE
Refine timestamp strategy selection in GUI

### DIFF
--- a/crates/psu-packer-gui/src/sas_timestamps.rs
+++ b/crates/psu-packer-gui/src/sas_timestamps.rs
@@ -153,12 +153,20 @@ pub(crate) fn planned_timestamp_for_folder(
     path: &Path,
     rules: &TimestampRules,
 ) -> Option<NaiveDateTime> {
-    let name = path.file_name()?.to_str()?.trim();
-    if name.is_empty() {
+    let name = path.file_name()?.to_str()?;
+    planned_timestamp_for_name(name, rules)
+}
+
+pub(crate) fn planned_timestamp_for_name(
+    name: &str,
+    rules: &TimestampRules,
+) -> Option<NaiveDateTime> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
         return None;
     }
 
-    let offset_seconds = deterministic_offset_seconds(name, rules)?;
+    let offset_seconds = deterministic_offset_seconds(trimmed, rules)?;
     let base = base_datetime_local_to_utc()?;
     let planned_utc = base - Duration::seconds(offset_seconds);
     let snapped = snap_even_second(planned_utc);


### PR DESCRIPTION
## Summary
- introduce a timestamp strategy enum with helpers to sync inherited, SAS, or manual values and reuse SAS planning for loaded PSUs
- extend the metadata timestamp UI to present radio options, manual editing controls, and source/planned status in all contexts
- update PSU and folder loading to capture source timestamps, keep strategy choices persistent, and recompute planned values after changes

## Testing
- `cargo test -p psu-packer-gui`


------
https://chatgpt.com/codex/tasks/task_e_68ca3c8b705c8321a3c0f5dd11495d0c