### PR TITLE
Add apply actions for psu.toml and title.cfg editors

### DIFF
--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -13,3 +13,4 @@ chrono = "0.4.42"
 egui_extras = { version = "0.27", features = ["chrono"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tempfile = "3"


### PR DESCRIPTION
## Summary
- add an Apply button to the psu.toml and title.cfg editors so changes can be synced without saving to disk
- implement helpers to parse edited psu.toml/title.cfg content, update app state, and report validation errors with new tests
- add the tempfile dependency so psu.toml content can be parsed through the existing loader

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ca4f3460a48321851039bb57ca6042