### PR TITLE
Add required file validation for PSU folders

### DIFF
--- a/crates/psu-packer-gui/src/ui/file_picker.rs
+++ b/crates/psu-packer-gui/src/ui/file_picker.rs
@@ -257,6 +257,12 @@ pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
 
         if let Some(folder) = &app.folder {
             ui.label(format!("Folder: {}", folder.display()));
+            if !app.missing_required_project_files.is_empty() {
+                let warning = PackerApp::format_missing_required_files_message(
+                    &app.missing_required_project_files,
+                );
+                ui.colored_label(egui::Color32::YELLOW, warning);
+            }
         }
     });
 }
@@ -362,6 +368,7 @@ impl PackerApp {
         self.clear_error_message();
         self.status = format!("Loaded PSU from {}", path.display());
         self.folder = None;
+        self.missing_required_project_files.clear();
         self.sync_timestamp_after_source_update();
         self.include_files.clear();
         self.exclude_files.clear();


### PR DESCRIPTION
## Summary
- record missing Standardized App Save files whenever a folder is selected and surface a warning in the folder and packaging sections
- block packing when any required file is absent and reuse the formatted list in the error message
- cover the new behaviour with unit tests that exercise every missing file scenario

## Testing
- cargo test -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68ca533c3a0483219b4ec3e10623955f