### PR TITLE
Allow configuring file filters without selecting a folder

### DIFF
--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -232,6 +232,8 @@ pub struct PackerApp {
     pub(crate) timestamp_rules_ui: TimestampRulesUiState,
     pub(crate) include_files: Vec<String>,
     pub(crate) exclude_files: Vec<String>,
+    pub(crate) include_manual_entry: String,
+    pub(crate) exclude_manual_entry: String,
     pub(crate) selected_include: Option<usize>,
     pub(crate) selected_exclude: Option<usize>,
     pub(crate) missing_required_project_files: Vec<String>,
@@ -317,6 +319,8 @@ impl Default for PackerApp {
             timestamp_rules_ui,
             include_files: Vec::new(),
             exclude_files: Vec::new(),
+            include_manual_entry: String::new(),
+            exclude_manual_entry: String::new(),
             selected_include: None,
             selected_exclude: None,
             missing_required_project_files: Vec::new(),
@@ -811,6 +815,8 @@ impl PackerApp {
         self.manual_timestamp = None;
         self.include_files.clear();
         self.exclude_files.clear();
+        self.include_manual_entry.clear();
+        self.exclude_manual_entry.clear();
         self.selected_include = None;
         self.selected_exclude = None;
         self.reset_icon_sys_fields();


### PR DESCRIPTION
## Summary
- always render the include/exclude filter lists and add manual entry controls when no folder is selected
- add helpers that accept manual filenames, reuse them from the browse handler, and track manual entry field state
- add tests that cover configuring manual filters with no source folder

## Testing
- cargo test -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68ca5aafedcc8321b7b4b2360a7e8dff