### PR TITLE
Improve metadata timestamp guidance

### DIFF
--- a/crates/psu-packer-gui/src/ui/pack_controls.rs
+++ b/crates/psu-packer-gui/src/ui/pack_controls.rs
@@ -238,7 +238,7 @@ mod tests {
     #[test]
     fn manual_filter_entries_allowed_without_folder() {
         let mut app = PackerApp::default();
-        app.selected_prefix = SasPrefix::Ps2;
+        app.selected_prefix = SasPrefix::App;
         app.folder_base_name = "SAVE".to_string();
 
         assert!(app.handle_add_file_from_entry(ListKind::Include, "BOOT.ELF"));


### PR DESCRIPTION
## Summary
- redesign the metadata timestamp section with grouped strategy guidance, recommended badges, and a summary banner so the current choice is explicit
- add helpers and ui tests to verify the new copy reacts to available metadata and manual edits
- fix the pack controls test to use a valid SAS prefix constant

## Testing
- cargo test -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68ca70271f8883219de7255f6c1c4965