### PR TITLE
Add Windows resource build script for psu-packer-gui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,6 +4124,8 @@ dependencies = [
  "rfd 0.14.1",
  "serde",
  "serde_json",
+ "tempfile",
+ "winresource",
 ]
 
 [[package]]

--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -14,3 +14,6 @@ egui_extras = { version = "0.27", features = ["chrono"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
+
+[build-dependencies]
+winresource = "0.1"

--- a/crates/psu-packer-gui/build.rs
+++ b/crates/psu-packer-gui/build.rs
@@ -1,0 +1,13 @@
+use {
+    std::{env, io},
+    winresource::WindowsResource,
+};
+
+fn main() -> io::Result<()> {
+    if env::var_os("CARGO_CFG_WINDOWS").is_some() {
+        WindowsResource::new()
+            .set_icon("../suitcase/assets/icon.ico")
+            .compile()?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add winresource as a build dependency for the psu-packer-gui crate
- add a build script that applies the suitcase icon when building on Windows

## Testing
- cargo check -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68ca87c569808321b0b38d822fc217c1