### PR TITLE
Lock PSU Packer GUI window size

### DIFF
--- a/crates/psu-packer-gui/src/main.rs
+++ b/crates/psu-packer-gui/src/main.rs
@@ -15,8 +15,14 @@ impl NativeOptionsExt for eframe::NativeOptions {
 }
 
 fn main() -> eframe::Result<()> {
+    let viewport = egui::ViewportBuilder::default()
+        .with_inner_size([1024.0, 768.0])
+        .with_min_inner_size([1024.0, 768.0])
+        .with_max_inner_size([1024.0, 768.0])
+        .with_resizable(false);
+
     let options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default().with_inner_size([1024.0, 768.0]),
+        viewport,
         ..Default::default()
     }
     .with_centered(true);


### PR DESCRIPTION
## Summary
- configure the viewport so the PSU Packer window stays at 1024×768 and cannot be resized

## Testing
- cargo build -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68caa3218864832190310b79eb449fb1