### PR TITLE
Center editor panels in packer GUI

### DIFF
--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -26,6 +26,7 @@ const ICON_SYS_UNSUPPORTED_CHAR_PLACEHOLDER: char = '\u{FFFD}';
 const TIMESTAMP_RULES_FILE: &str = "timestamp_rules.json";
 pub(crate) const REQUIRED_PROJECT_FILES: &[&str] =
     &["icon.icn", "icon.sys", "psu.toml", "title.cfg"];
+const CENTERED_COLUMN_MAX_WIDTH: f32 = 720.0;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum MissingFileReason {
@@ -1862,27 +1863,29 @@ impl eframe::App for PackerApp {
             match self.editor_tab {
                 EditorTab::PsuSettings => {
                     egui::ScrollArea::vertical().show(ui, |ui| {
-                        ui::file_picker::folder_section(self, ui);
+                        ui::centered_column(ui, CENTERED_COLUMN_MAX_WIDTH, |ui| {
+                            ui::file_picker::folder_section(self, ui);
 
-                        let showing_psu = self.showing_loaded_psu();
-                        if showing_psu {
+                            let showing_psu = self.showing_loaded_psu();
+                            if showing_psu {
+                                ui.add_space(8.0);
+                                ui::file_picker::loaded_psu_section(self, ui);
+                            }
+
                             ui.add_space(8.0);
-                            ui::file_picker::loaded_psu_section(self, ui);
-                        }
+                            ui::pack_controls::metadata_section(self, ui);
 
-                        ui.add_space(8.0);
-                        ui::pack_controls::metadata_section(self, ui);
+                            if !showing_psu {
+                                ui.add_space(8.0);
+                                ui::pack_controls::file_filters_section(self, ui);
+                            }
 
-                        if !showing_psu {
                             ui.add_space(8.0);
-                            ui::pack_controls::file_filters_section(self, ui);
-                        }
+                            ui::pack_controls::output_section(self, ui);
 
-                        ui.add_space(8.0);
-                        ui::pack_controls::output_section(self, ui);
-
-                        ui.add_space(8.0);
-                        ui::pack_controls::packaging_section(self, ui);
+                            ui.add_space(8.0);
+                            ui::pack_controls::packaging_section(self, ui);
+                        });
                     });
                 }
                 EditorTab::PsuToml => {
@@ -1945,12 +1948,16 @@ impl eframe::App for PackerApp {
                 }
                 EditorTab::IconSys => {
                     egui::ScrollArea::vertical().show(ui, |ui| {
-                        ui::icon_sys::icon_sys_editor(self, ui);
+                        ui::centered_column(ui, CENTERED_COLUMN_MAX_WIDTH, |ui| {
+                            ui::icon_sys::icon_sys_editor(self, ui);
+                        });
                     });
                 }
                 EditorTab::TimestampAuto => {
                     egui::ScrollArea::vertical().show(ui, |ui| {
-                        ui::timestamps::timestamp_rules_editor(self, ui);
+                        ui::centered_column(ui, CENTERED_COLUMN_MAX_WIDTH, |ui| {
+                            ui::timestamps::timestamp_rules_editor(self, ui);
+                        });
                     });
                 }
             }

--- a/crates/psu-packer-gui/src/ui/icon_sys.rs
+++ b/crates/psu-packer-gui/src/ui/icon_sys.rs
@@ -273,7 +273,6 @@ fn title_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
     ui.group(|ui| {
         ui.heading("Title");
         ui.small("Each line supports up to 10 ASCII characters.");
-        ui.add_space(4.0);
 
         egui::Grid::new("icon_sys_title_grid")
             .num_columns(2)
@@ -351,7 +350,6 @@ fn flag_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
     let mut changed = false;
     ui.group(|ui| {
         ui.heading("Flags");
-        ui.add_space(4.0);
         egui::Grid::new("icon_sys_flag_grid")
             .num_columns(2)
             .spacing(egui::vec2(8.0, 4.0))
@@ -405,7 +403,6 @@ fn presets_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
     ui.group(|ui| {
         ui.heading("Presets");
         ui.small("Choose a preset to populate the colors and lights automatically.");
-        ui.add_space(4.0);
 
         let selected_label = match app.icon_sys_selected_preset.as_deref() {
             Some(id) => find_preset(id)
@@ -474,7 +471,6 @@ fn background_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
     ui.group(|ui| {
         ui.heading("Background");
         ui.small("Adjust the gradient colors and alpha layer.");
-        ui.add_space(4.0);
 
         if ui
             .add(
@@ -489,7 +485,6 @@ fn background_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
             changed = true;
         }
 
-        ui.add_space(4.0);
         let mut background_changed = false;
         egui::Grid::new("icon_sys_background_grid")
             .num_columns(2)
@@ -518,7 +513,6 @@ fn lighting_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
     ui.group(|ui| {
         ui.heading("Lighting");
         ui.small("Tweak light directions, colors, and the ambient glow.");
-        ui.add_space(4.0);
 
         let mut lighting_changed = false;
 

--- a/crates/psu-packer-gui/src/ui/mod.rs
+++ b/crates/psu-packer-gui/src/ui/mod.rs
@@ -1,5 +1,23 @@
+use eframe::egui;
+
 pub mod dialogs;
 pub mod file_picker;
 pub mod icon_sys;
 pub mod pack_controls;
 pub mod timestamps;
+
+pub(crate) fn centered_column<R>(
+    ui: &mut egui::Ui,
+    max_width: f32,
+    add_contents: impl FnOnce(&mut egui::Ui) -> R,
+) -> R {
+    let width = ui.available_width().min(max_width);
+    ui.vertical_centered(|ui| {
+        ui.set_width(width);
+        ui.with_layout(egui::Layout::top_down(egui::Align::Center), |ui| {
+            add_contents(ui)
+        })
+        .inner
+    })
+    .inner
+}

--- a/crates/psu-packer-gui/src/ui/timestamps.rs
+++ b/crates/psu-packer-gui/src/ui/timestamps.rs
@@ -41,7 +41,6 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                         app.set_timestamp_strategy(strategy);
                     }
                 });
-                ui.add_space(4.0);
                 ui.label("• Use when verifying contents does not require metadata timestamps.");
                 ui.label("• Relies on: no metadata—timestamp field will be omitted.");
             });
@@ -67,7 +66,6 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                         app.set_timestamp_strategy(strategy);
                     }
                 });
-                ui.add_space(4.0);
                 ui.label("• Use when the loaded source already contains a trusted timestamp.");
                 ui.label(format!(
                     "• Relies on: Source timestamp ({}).",
@@ -99,7 +97,6 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                         app.set_timestamp_strategy(strategy);
                     }
                 });
-                ui.add_space(4.0);
                 ui.label("• Use when project names follow SAS conventions for deterministic scheduling.");
                 let project_name = project_name_text(app);
                 ui.label(format!(
@@ -134,7 +131,6 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                         app.set_timestamp_strategy(strategy);
                     }
                 });
-                ui.add_space(4.0);
                 ui.label("• Use when you must pin the archive to an explicit, reviewer-approved timestamp.");
                 ui.label("• Relies on: Manual date and time you enter here.");
 
@@ -319,15 +315,12 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
     }
 
     if let Some(path) = app.timestamp_rules_path() {
-        ui.add_space(4.0);
         ui.label(format!("Configuration file: {}", path.display()));
     } else {
-        ui.add_space(4.0);
         ui.small("Select a project folder to save these settings alongside psu.toml.");
     }
 
     if app.timestamp_rules_modified {
-        ui.add_space(4.0);
         ui.colored_label(egui::Color32::LIGHT_YELLOW, "Unsaved changes");
     }
 
@@ -402,7 +395,6 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
                     }
                 });
 
-                ui.add_space(4.0);
                 ui.label("Aliases (one per line):");
                 if let Some(buffer) = app.timestamp_rules_ui.alias_texts.get_mut(index) {
                     if ui


### PR DESCRIPTION
## Summary
- add a reusable `centered_column` helper that constrains width while centering child widgets
- apply the helper around the PSU settings, icon.sys, and timestamp editors so their controls stay centered
- tidy redundant spacing in the icon.sys and timestamp UIs now that the shared helper handles layout

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68caa934b9d083218b6f604521ee0f1e