### PR TITLE
Enable ICO decoding for suitcase icon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1df21f715862ede32a0c525ce2ca4d52626bb0007f8c18b87a384503ac33e70"
 dependencies = [
  "clipboard-win",
- "image 0.25.6",
+ "image 0.25.8",
  "log",
  "objc2 0.6.0",
  "objc2-app-kit 0.3.0",
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e335041290c43101ca215eed6f43ec437eb5a42125573f600fc3fa42b9bddd62"
+checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
 dependencies = [
  "arrayvec",
 ]
@@ -1536,7 +1536,7 @@ dependencies = [
  "glutin 0.32.2",
  "glutin-winit 0.5.0",
  "home",
- "image 0.25.6",
+ "image 0.25.8",
  "js-sys",
  "log",
  "objc2 0.5.2",
@@ -1700,7 +1700,7 @@ dependencies = [
  "ahash",
  "egui 0.31.1",
  "enum-map",
- "image 0.25.6",
+ "image 0.25.8",
  "log",
  "mime_guess2",
  "profiling",
@@ -1957,6 +1957,26 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "fdeflate"
@@ -2681,14 +2701,14 @@ dependencies = [
  "byteorder",
  "color_quant",
  "num-traits",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
 name = "image"
-version = "0.25.6"
+version = "0.25.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
+checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -2696,8 +2716,9 @@ dependencies = [
  "exr",
  "gif",
  "image-webp",
+ "moxcms",
  "num-traits",
- "png",
+ "png 0.18.0",
  "qoi",
  "ravif",
  "rayon",
@@ -2845,12 +2866,6 @@ dependencies = [
  "getrandom 0.3.2",
  "libc",
 ]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -3158,6 +3173,16 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -3952,6 +3977,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.9.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4075,7 +4113,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "chrono",
- "image 0.25.6",
+ "image 0.25.8",
  "indexmap",
  "toml 0.9.5",
 ]
@@ -4085,7 +4123,7 @@ name = "ps2-mcm"
 version = "0.1.0"
 dependencies = [
  "eframe 0.31.1",
- "image 0.25.6",
+ "image 0.25.8",
  "ps2-filetypes",
  "rfd 0.15.3",
 ]
@@ -4127,6 +4165,15 @@ dependencies = [
  "serde_json",
  "tempfile",
  "winresource",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55f4fedc84ed39cb7a489322318976425e42a147e2be79d8f878e2884f94e84"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4274,9 +4321,9 @@ dependencies = [
 
 [[package]]
 name = "ravif"
-version = "0.11.11"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2413fd96bd0ea5cdeeb37eaf446a22e6ed7b981d792828721e74ded1980a45c6"
+checksum = "5825c26fddd16ab9f515930d49028a630efec172e903483c94796cfe31893e6b"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -4883,7 +4930,7 @@ dependencies = [
  "eframe 0.31.1",
  "egui_dock",
  "egui_extras 0.31.1",
- "image 0.25.6",
+ "image 0.25.8",
  "macros",
  "notify",
  "ps2-filetypes",
@@ -5021,13 +5068,16 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.9.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
 dependencies = [
+ "fax",
  "flate2",
- "jpeg-decoder",
+ "half",
+ "quick-error",
  "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5041,7 +5091,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png",
+ "png 0.17.16",
  "tiny-skia-path",
 ]
 
@@ -5661,9 +5711,9 @@ dependencies = [
 
 [[package]]
 name = "weezl"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "wgpu"
@@ -6966,9 +7016,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.13"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16099418600b4d8f028622f73ff6e3deaabdff330fb9a2a131dea781ee8b0768"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
 ]

--- a/crates/suitcase/Cargo.toml
+++ b/crates/suitcase/Cargo.toml
@@ -10,7 +10,7 @@ egui_extras = { version = "0.31.1", features = ["svg", "image"] }
 egui_dock = "0.16.0"
 cgmath = "0.18.0"
 ps2-filetypes = { path = "../ps2-filetypes" }
-image = { version = "0.25.6" }
+image = { version = "0.25.6", features = ["ico"] }
 rfd = "0.15.3"
 wavefront_obj = "11.0.0"
 bytesize = "2.0.1"

--- a/crates/suitcase/src/main.rs
+++ b/crates/suitcase/src/main.rs
@@ -37,14 +37,25 @@ fn main() -> eframe::Result<()> {
             .with_inner_size([1920.0, 1080.0])
             .with_icon({
                 let icon = include_bytes!("../assets/icon.ico");
-                let image = image::load_from_memory(icon).expect("Failed to load icon");
-                let image = image.into_rgba8();
-                let (width, height) = image.dimensions();
+                match image::load_from_memory(icon) {
+                    Ok(image) => {
+                        let image = image.into_rgba8();
+                        let (width, height) = image.dimensions();
 
-                IconData {
-                    rgba: image.into_raw(),
-                    width,
-                    height,
+                        IconData {
+                            rgba: image.into_raw(),
+                            width,
+                            height,
+                        }
+                    }
+                    Err(error) => {
+                        eprintln!("Failed to load icon: {error}");
+                        IconData {
+                            rgba: vec![0; 4],
+                            width: 1,
+                            height: 1,
+                        }
+                    }
                 }
             }),
         multisampling: 4,


### PR DESCRIPTION
## Summary
- enable ICO support on the `image` dependency used by the suitcase crate so the embedded icon can be decoded
- guard the GUI icon loading against decode errors by logging the failure and substituting a minimal placeholder icon
- refresh `Cargo.lock` to capture the updated `image` feature set and transitive dependencies

## Testing
- cargo check -p suitcase

------
https://chatgpt.com/codex/tasks/task_e_68cabab26d84832184ca8920caa95245