### PR TITLE
Add renderer fallback for PSU Packer GUI

### DIFF
--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -7,7 +7,7 @@ version.workspace = true
 [dependencies]
 psu-packer = { path = "../psu-packer" }
 ps2-filetypes = { path = "../ps2-filetypes" }
-eframe = "0.27"
+eframe = { version = "0.27", features = ["default", "wgpu"] }
 rfd = "0.14"
 chrono = "0.4.42"
 egui_extras = { version = "0.27", features = ["chrono"] }

--- a/crates/psu-packer-gui/src/main.rs
+++ b/crates/psu-packer-gui/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use eframe::egui;
+use eframe::{egui, NativeOptions, Renderer};
 use psu_packer_gui::PackerApp;
 
 trait NativeOptionsExt {
@@ -15,21 +15,59 @@ impl NativeOptionsExt for eframe::NativeOptions {
 }
 
 fn main() -> eframe::Result<()> {
-    let viewport = egui::ViewportBuilder::default()
-        .with_inner_size([1024.0, 768.0])
-        .with_min_inner_size([1024.0, 768.0])
-        .with_max_inner_size([1024.0, 768.0])
-        .with_resizable(false);
+    let wgpu_result = run_app(create_native_options(Renderer::Wgpu));
 
-    let options = eframe::NativeOptions {
-        viewport,
+    match wgpu_result {
+        Ok(result) => Ok(result),
+        Err(wgpu_error) => {
+            report_renderer_error("WGPU", &wgpu_error);
+
+            let glow_result = run_app(create_native_options(Renderer::Glow));
+            match glow_result {
+                Ok(result) => Ok(result),
+                Err(glow_error) => {
+                    report_renderer_error("Glow", &glow_error);
+                    Err(wgpu_error)
+                }
+            }
+        }
+    }
+}
+
+fn create_native_options(renderer: Renderer) -> NativeOptions {
+    NativeOptions {
+        viewport: egui::ViewportBuilder::default()
+            .with_inner_size([1024.0, 768.0])
+            .with_min_inner_size([1024.0, 768.0])
+            .with_max_inner_size([1024.0, 768.0])
+            .with_resizable(false),
+        renderer,
         ..Default::default()
     }
-    .with_centered(true);
+    .with_centered(true)
+}
 
+fn run_app(options: NativeOptions) -> eframe::Result<()> {
     eframe::run_native(
         "PSU Packer",
         options,
         Box::new(|cc| Box::new(PackerApp::new(cc))),
     )
+}
+
+fn report_renderer_error(renderer: &str, error: &eframe::Error) {
+    eprintln!("Failed to initialize {renderer} renderer: {error}");
+
+    #[cfg(target_os = "windows")]
+    {
+        use rfd::MessageDialog;
+
+        MessageDialog::new()
+            .set_title("PSU Packer")
+            .set_description(&format!(
+                "Failed to initialize {renderer} renderer:\n{error}\n\nAttempting fallback..."
+            ))
+            .set_buttons(rfd::MessageButtons::Ok)
+            .show();
+    }
 }


### PR DESCRIPTION
## Summary
- add startup fallback to launch PSU Packer GUI with WGPU first and fall back to Glow with error reporting
- extract helper to build the viewport options while selecting the requested renderer
- enable the wgpu feature on the eframe dependency

## Testing
- cargo check -p psu-packer-gui


------
https://chatgpt.com/codex/tasks/task_e_68cac7e6990083219e7c0846eecdd498