### PR TITLE
Request realistic depth buffer

### DIFF
--- a/crates/suitcase/src/main.rs
+++ b/crates/suitcase/src/main.rs
@@ -79,7 +79,10 @@ fn create_native_options(renderer: eframe::Renderer) -> NativeOptions {
                 }
             }),
         multisampling: 4,
-        depth_buffer: 1,
+        // Request a standard 24-bit depth buffer. WGPU expects at least 24 bits
+        // on most platforms, and Glow gracefully ignores the request when it
+        // cannot provide a depth buffer.
+        depth_buffer: 24,
         renderer,
         ..Default::default()
     }


### PR DESCRIPTION
## Summary
- request a standard 24-bit depth buffer when constructing eframe native options and document why the value is safe for both WGPU and Glow

## Testing
- cargo build
- cargo build --release

------
https://chatgpt.com/codex/tasks/task_e_68cadd5cb6708321b570b215d87e80b3