### PR TITLE
Handle folder access errors gracefully

### DIFF
--- a/crates/suitcase/src/io/read_folder.rs
+++ b/crates/suitcase/src/io/read_folder.rs
@@ -3,17 +3,49 @@ use crate::data::virtual_file::VirtualFile;
 use std::path::PathBuf;
 
 pub fn read_folder(folder: PathBuf) -> std::io::Result<Files> {
-    let files = std::fs::read_dir(folder)?
+    let files = std::fs::read_dir(&folder)?
         .into_iter()
-        .flatten()
-        .filter_map(|entry| {
-            if entry.file_type().ok()?.is_file() {
-                Some(VirtualFile {
-                    name: entry.file_name().into_string().unwrap(),
-                    file_path: entry.path(),
-                    size: entry.path().metadata().unwrap().len(),
-                })
-            } else {
+        .filter_map(|entry| match entry {
+            Ok(entry) => {
+                if entry.file_type().ok()?.is_file() {
+                    let file_path = entry.path();
+                    let name = match entry.file_name().into_string() {
+                        Ok(name) => name,
+                        Err(os_string) => {
+                            eprintln!(
+                                "Skipping file '{:?}' in '{}' due to invalid UTF-8 name",
+                                os_string,
+                                folder.display()
+                            );
+                            return None;
+                        }
+                    };
+                    let metadata = match file_path.metadata() {
+                        Ok(metadata) => metadata,
+                        Err(err) => {
+                            eprintln!(
+                                "Skipping file '{}' in '{}' due to metadata error: {err}",
+                                file_path.display(),
+                                folder.display()
+                            );
+                            return None;
+                        }
+                    };
+
+                    Some(VirtualFile {
+                        name,
+                        file_path,
+                        size: metadata.len(),
+                    })
+                } else {
+                    None
+                }
+            }
+            Err(err) => {
+                eprintln!(
+                    "Failed to read directory entry in '{}': {err}",
+                    folder.display()
+                );
                 None
             }
         })


### PR DESCRIPTION
## Summary
- update the file tree indexer to propagate directory read errors and log skipped entries instead of panicking
- make folder reading skip unreadable files while reporting why they were ignored
- handle folder load failures in PSUBuilderApp by reporting errors, clearing state, and keeping the UI responsive

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cae40db3d48321804f6fae28adf58f