### PR TITLE
Improve renderer fallback handling

### DIFF
--- a/crates/suitcase/Cargo.toml
+++ b/crates/suitcase/Cargo.toml
@@ -3,6 +3,11 @@ name = "suitcase"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["glow", "wgpu"]
+glow = []
+wgpu = ["eframe/wgpu"]
+
 [dependencies]
 macros = { path = "../macros" }
 eframe = { version = "0.31.1", features = ["default", "persistence"] }


### PR DESCRIPTION
## Summary
- add feature flags for glow and wgpu so both renderers can be configured explicitly
- refactor native option construction to accept a multisampling value and introduce renderer retry logic with panic handling
- surface fallback errors through the existing dialog, including a retry with reduced multisampling for both WGPU and Glow

## Testing
- `cargo check -p suitcase` *(fails: pre-existing borrow checker error in crates/suitcase/src/components/file_tree.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68cb003897848321a2af8c45ae8cbb77