### PR TITLE
Add renderer feature guards

### DIFF
--- a/crates/suitcase/build.rs
+++ b/crates/suitcase/build.rs
@@ -4,6 +4,16 @@ use {
 };
 
 fn main() -> io::Result<()> {
+    let has_wgpu = env::var_os("CARGO_FEATURE_WGPU").is_some();
+    let has_glow = env::var_os("CARGO_FEATURE_GLOW").is_some();
+
+    if !has_wgpu && !has_glow {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "PS2Suitcase requires either the `wgpu` or `glow` feature to be enabled.",
+        ));
+    }
+
     if env::var_os("CARGO_CFG_WINDOWS").is_some() {
         WindowsResource::new()
             // This path can be absolute, or relative to your crate root.

--- a/crates/suitcase/src/main.rs
+++ b/crates/suitcase/src/main.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+#[cfg(not(any(feature = "wgpu", feature = "glow")))]
+compile_error!("PS2Suitcase must be built with at least one renderer feature enabled: enable either the \"wgpu\" feature, the \"glow\" feature, or both.");
+
 mod components;
 mod data;
 mod io;


### PR DESCRIPTION
## Summary
- fail the build when neither the `wgpu` nor `glow` renderer features are enabled
- make the build script return a descriptive error if no renderer feature is selected

## Testing
- cargo fmt
- cargo check -p suitcase *(fails with existing borrow checker error in `components/file_tree.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0a2d1a488321b1a8e996947d9beb