### PR TITLE
Improve PSU output defaults and timestamp UI

### DIFF
--- a/crates/psu-packer-gui/src/ui/file_picker.rs
+++ b/crates/psu-packer-gui/src/ui/file_picker.rs
@@ -183,7 +183,12 @@ pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
 
                             app.set_folder_name_from_full(&name);
                             app.psu_file_base_name = app.folder_base_name.clone();
-                            app.output = app.default_output_file_name().unwrap_or_default();
+                            if let Some(default_path) = app.default_output_path_with(Some(&folder))
+                            {
+                                app.output = default_path.display().to_string();
+                            } else {
+                                app.output.clear();
+                            }
                             app.source_timestamp = timestamp;
                             app.include_files = include.unwrap_or_default();
                             app.exclude_files = exclude.unwrap_or_default();

--- a/crates/psu-packer-gui/src/ui/timestamps.rs
+++ b/crates/psu-packer-gui/src/ui/timestamps.rs
@@ -32,7 +32,7 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                     let response = ui.radio_value(
                         &mut strategy,
                         TimestampStrategy::None,
-                        "Do not save a timestamp",
+                        "No timestamp",
                     );
                     if response.changed()
                         && app.timestamp_strategy != TimestampStrategy::None
@@ -54,7 +54,7 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                     let response = ui.radio_value(
                         &mut strategy,
                         TimestampStrategy::InheritSource,
-                        "Inherit timestamp from the loaded folder or PSU",
+                        "Use source timestamp",
                     );
                     if recommended_strategy == Some(TimestampStrategy::InheritSource) {
                         recommended_badge(ui);
@@ -85,7 +85,7 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                     let response = ui.radio_value(
                         &mut strategy,
                         TimestampStrategy::SasRules,
-                        "Apply SAS timestamp rules",
+                        "Use SAS prefix rules",
                     );
                     if recommended_strategy == Some(TimestampStrategy::SasRules) {
                         recommended_badge(ui);
@@ -119,7 +119,7 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                     let response = ui.radio_value(
                         &mut strategy,
                         TimestampStrategy::Manual,
-                        "Enter timestamp manually",
+                        "Manual timestamp",
                     );
                     if recommended_strategy == Some(TimestampStrategy::Manual) {
                         recommended_badge(ui);
@@ -512,7 +512,7 @@ mod tests {
 
         let rendered = render_metadata_text(&mut app);
 
-        assert!(rendered.contains("Do not save a timestamp"));
+        assert!(rendered.contains("No timestamp"));
         assert!(rendered.contains("Source timestamp (available)"));
         assert!(rendered.contains(
             "Currently using: Inherited source timestamp because the loaded source provided 2024-01-02 03:04:05 to preserve."


### PR DESCRIPTION
## Summary
- ensure PSU file defaults copy the folder name when blank and build full output paths using the current project or saved location
- update the output browser dialog and label to clarify where the archive will be saved
- simplify timestamp radio labels and default to the recommended strategy while covering the new behavior with tests

## Testing
- `cargo test -p psu-packer-gui`


------
https://chatgpt.com/codex/tasks/task_e_68cb30bb78b48321b1a6824a978eccb6