### PR TITLE
Adjust GUI theme to PS2 palette

### DIFF
--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -1850,7 +1850,7 @@ impl eframe::App for PackerApp {
                 );
                 let separator_rect =
                     egui::Rect::from_min_max(egui::pos2(rect.min.x, rect.max.y - 2.0), rect.max);
-                theme::draw_separator(ui.painter(), separator_rect, self.theme.neon_accent);
+                theme::draw_separator(ui.painter(), separator_rect, self.theme.separator);
                 egui::menu::bar(ui, |ui| {
                     ui::file_picker::file_menu(self, ui);
                 });
@@ -1868,10 +1868,10 @@ impl eframe::App for PackerApp {
                 );
                 let top_separator =
                     egui::Rect::from_min_max(rect.min, egui::pos2(rect.max.x, rect.min.y + 2.0));
-                theme::draw_separator(ui.painter(), top_separator, self.theme.neon_accent);
+                theme::draw_separator(ui.painter(), top_separator, self.theme.separator);
                 let bottom_separator =
                     egui::Rect::from_min_max(egui::pos2(rect.min.x, rect.max.y - 2.0), rect.max);
-                theme::draw_separator(ui.painter(), bottom_separator, self.theme.neon_accent);
+                theme::draw_separator(ui.painter(), bottom_separator, self.theme.separator);
                 ui.add_space(8.0);
 
                 let tab_bar = ui.horizontal(|ui| {
@@ -1879,13 +1879,14 @@ impl eframe::App for PackerApp {
                     let mut tab_button =
                         |ui: &mut egui::Ui, tab: EditorTab, label: &str, highlight: bool| {
                             let is_selected = self.editor_tab == tab;
-                            let mut text = egui::RichText::new(label).font(tab_font.clone()).color(
-                                if is_selected || highlight {
-                                    self.theme.neon_accent
-                                } else {
-                                    self.theme.soft_accent
-                                },
-                            );
+                            let base_color = if is_selected || highlight {
+                                self.theme.neon_accent
+                            } else {
+                                self.theme.soft_accent.gamma_multiply(0.85)
+                            };
+                            let mut text = egui::RichText::new(label)
+                                .font(tab_font.clone())
+                                .color(base_color);
                             if is_selected {
                                 text = text.strong();
                             }
@@ -1934,7 +1935,7 @@ impl eframe::App for PackerApp {
                     egui::pos2(rect.min.x, tab_rect.max.y + 4.0),
                     egui::pos2(rect.max.x, tab_rect.max.y + 6.0),
                 );
-                theme::draw_separator(ui.painter(), tab_separator, self.theme.neon_accent);
+                theme::draw_separator(ui.painter(), tab_separator, self.theme.separator);
                 ui.add_space(10.0);
 
                 match self.editor_tab {

--- a/crates/psu-packer-gui/src/ui/theme.rs
+++ b/crates/psu-packer-gui/src/ui/theme.rs
@@ -21,16 +21,16 @@ pub struct Palette {
 impl Default for Palette {
     fn default() -> Self {
         Self {
-            background: Color32::from_rgb(8, 10, 28),
-            panel: Color32::from_rgb(16, 20, 46),
-            header_top: Color32::from_rgb(20, 32, 72),
-            header_bottom: Color32::from_rgb(16, 64, 112),
-            footer_top: Color32::from_rgb(12, 24, 60),
-            footer_bottom: Color32::from_rgb(12, 48, 92),
-            neon_accent: Color32::from_rgb(48, 188, 255),
-            soft_accent: Color32::from_rgb(96, 160, 255),
-            separator: Color32::from_rgb(0, 120, 200),
-            text_primary: Color32::from_rgb(208, 220, 255),
+            background: Color32::from_rgb(6, 8, 20),
+            panel: Color32::from_rgb(18, 38, 52),
+            header_top: Color32::from_rgb(12, 16, 40),
+            header_bottom: Color32::from_rgb(60, 40, 120),
+            footer_top: Color32::from_rgb(16, 30, 52),
+            footer_bottom: Color32::from_rgb(52, 52, 112),
+            neon_accent: Color32::from_rgb(150, 92, 255),
+            soft_accent: Color32::from_rgb(124, 148, 220),
+            separator: Color32::from_rgb(88, 68, 168),
+            text_primary: Color32::from_rgb(214, 220, 240),
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the default palette with near-black/navy foundations, teal panels, and violet accents inspired by the PS2 mood board
- adjust tab text and separator accents in `PackerApp::update` to stay readable with the new palette

## Testing
- `cargo fmt`
- `cargo check -p psu-packer-gui`
- `cargo run -p psu-packer-gui` *(fails: no DISPLAY/WAYLAND available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb30fc00b08321929c3845cef9280c