### PR TITLE
Allow resizing GUI window

### DIFF
--- a/crates/psu-packer-gui/src/main.rs
+++ b/crates/psu-packer-gui/src/main.rs
@@ -36,9 +36,8 @@ fn shared_native_options() -> NativeOptions {
     let mut options = NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([1024.0, 768.0])
-            .with_min_inner_size([1024.0, 768.0])
-            .with_max_inner_size([1024.0, 768.0])
-            .with_resizable(false),
+            .with_min_inner_size([640.0, 480.0])
+            .with_resizable(true),
         ..Default::default()
     };
 


### PR DESCRIPTION
## Summary
- allow the native window to be resized by dropping the fixed max inner size, lowering the minimum size, and enabling viewport resizing

## Testing
- cargo run -p psu-packer-gui *(fails: requires a display server and was interrupted once the build finished)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3646716c832182798f21233510f1