### PR TITLE
Refine display font usage

### DIFF
--- a/crates/psu-packer-gui/src/ui/file_picker.rs
+++ b/crates/psu-packer-gui/src/ui/file_picker.rs
@@ -3,7 +3,7 @@ use std::{fs, path::Path};
 use eframe::egui;
 use ps2_filetypes::{IconSys, PSUEntryKind, PSU};
 
-use crate::{PackerApp, SasPrefix, TimestampStrategy};
+use crate::{ui::theme, PackerApp, SasPrefix, TimestampStrategy};
 
 pub(crate) fn file_menu(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.menu_button("File", |ui| {
@@ -158,7 +158,7 @@ mod tests {
 
 pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.group(|ui| {
-        ui.heading("Folder");
+        ui.heading(theme::display_heading_text(ui, "Folder"));
         ui.small("Select the PSU project folder containing psu.toml.");
         ui.horizontal(|ui| {
             let spacing = ui.spacing().item_spacing.x;
@@ -289,7 +289,7 @@ pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
 
 pub(crate) fn loaded_psu_section(app: &PackerApp, ui: &mut egui::Ui) {
     ui.group(|ui| {
-        ui.heading("Loaded PSU");
+        ui.heading(theme::display_heading_text(ui, "Loaded PSU"));
         ui.small("Review the files discovered in the opened PSU archive.");
         if let Some(path) = &app.loaded_psu_path {
             ui.label(format!("File: {}", path.display()));

--- a/crates/psu-packer-gui/src/ui/icon_sys.rs
+++ b/crates/psu-packer-gui/src/ui/icon_sys.rs
@@ -1,6 +1,8 @@
 use eframe::egui::{self, Color32};
 
-use crate::{IconFlagSelection, PackerApp, ICON_SYS_FLAG_OPTIONS, ICON_SYS_TITLE_CHAR_LIMIT};
+use crate::{
+    ui::theme, IconFlagSelection, PackerApp, ICON_SYS_FLAG_OPTIONS, ICON_SYS_TITLE_CHAR_LIMIT,
+};
 use psu_packer::{ColorConfig, ColorFConfig, IconSysConfig, VectorConfig};
 
 const TITLE_CHAR_LIMIT: usize = ICON_SYS_TITLE_CHAR_LIMIT;
@@ -184,7 +186,7 @@ const ICON_SYS_PRESETS: &[IconSysPreset] = &[
 ];
 
 pub(crate) fn icon_sys_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
-    ui.heading("icon.sys metadata");
+    ui.heading(theme::display_heading_text(ui, "icon.sys metadata"));
     ui.small("Configure the save icon title, flags, and lighting.");
     ui.add_space(8.0);
 
@@ -271,7 +273,7 @@ pub(crate) fn icon_sys_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
 fn title_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
     let mut changed = false;
     ui.group(|ui| {
-        ui.heading("Title");
+        ui.heading(theme::display_heading_text(ui, "Title"));
         ui.small("Each line supports up to 10 ASCII characters.");
 
         egui::Grid::new("icon_sys_title_grid")
@@ -349,7 +351,7 @@ fn title_input(ui: &mut egui::Ui, id: egui::Id, value: &mut String) -> bool {
 fn flag_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
     let mut changed = false;
     ui.group(|ui| {
-        ui.heading("Flags");
+        ui.heading(theme::display_heading_text(ui, "Flags"));
         egui::Grid::new("icon_sys_flag_grid")
             .num_columns(2)
             .spacing(egui::vec2(8.0, 4.0))
@@ -401,7 +403,7 @@ fn flag_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
 fn presets_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
     let mut changed = false;
     ui.group(|ui| {
-        ui.heading("Presets");
+        ui.heading(theme::display_heading_text(ui, "Presets"));
         ui.small("Choose a preset to populate the colors and lights automatically.");
 
         let selected_label = match app.icon_sys_selected_preset.as_deref() {
@@ -469,7 +471,7 @@ fn draw_color_swatch(ui: &mut egui::Ui, color: Color32) {
 fn background_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
     let mut changed = false;
     ui.group(|ui| {
-        ui.heading("Background");
+        ui.heading(theme::display_heading_text(ui, "Background"));
         ui.small("Adjust the gradient colors and alpha layer.");
 
         if ui
@@ -511,7 +513,7 @@ fn background_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
 fn lighting_section(app: &mut PackerApp, ui: &mut egui::Ui) -> bool {
     let mut changed = false;
     ui.group(|ui| {
-        ui.heading("Lighting");
+        ui.heading(theme::display_heading_text(ui, "Lighting"));
         ui.small("Tweak light directions, colors, and the ambient glow.");
 
         let mut lighting_changed = false;

--- a/crates/psu-packer-gui/src/ui/pack_controls.rs
+++ b/crates/psu-packer-gui/src/ui/pack_controls.rs
@@ -2,11 +2,11 @@ use std::path::Path;
 
 use eframe::egui;
 
-use crate::{PackerApp, SasPrefix, ICON_SYS_TITLE_CHAR_LIMIT};
+use crate::{ui::theme, PackerApp, SasPrefix, ICON_SYS_TITLE_CHAR_LIMIT};
 
 pub(crate) fn metadata_section(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.group(|ui| {
-        ui.heading("Metadata");
+        ui.heading(theme::display_heading_text(ui, "Metadata"));
         ui.small("Edit PSU metadata before or after selecting a folder.");
         let previous_default_output = app.default_output_file_name();
         let mut metadata_changed = false;
@@ -87,7 +87,7 @@ pub(crate) fn metadata_section(app: &mut PackerApp, ui: &mut egui::Ui) {
 
 pub(crate) fn file_filters_section(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.group(|ui| {
-        ui.heading("File filters");
+        ui.heading(theme::display_heading_text(ui, "File filters"));
         ui.small("Manage which files to include or exclude before creating the archive.");
         let folder_selected = app.folder.is_some();
         if !folder_selected {
@@ -139,7 +139,7 @@ pub(crate) fn file_filters_section(app: &mut PackerApp, ui: &mut egui::Ui) {
 
 pub(crate) fn output_section(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.group(|ui| {
-        ui.heading("Output");
+        ui.heading(theme::display_heading_text(ui, "Output"));
         ui.small("Choose where the packed PSU file will be saved.");
         egui::Grid::new("output_grid")
             .num_columns(2)
@@ -164,7 +164,7 @@ pub(crate) fn output_section(app: &mut PackerApp, ui: &mut egui::Ui) {
 
 pub(crate) fn packaging_section(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.group(|ui| {
-        ui.heading("Packaging");
+        ui.heading(theme::display_heading_text(ui, "Packaging"));
         ui.small("Validate the configuration and generate the PSU archive.");
         let pack_in_progress = app.is_pack_running();
         if !app.missing_required_project_files.is_empty() {

--- a/crates/psu-packer-gui/src/ui/theme.rs
+++ b/crates/psu-packer-gui/src/ui/theme.rs
@@ -1,5 +1,6 @@
 use eframe::egui::{
-    self, Color32, FontData, FontDefinitions, FontFamily, FontId, Margin, Style, Vec2,
+    self, Color32, FontData, FontDefinitions, FontFamily, FontId, Margin, RichText, Style,
+    TextStyle, Vec2,
 };
 
 pub const DISPLAY_FONT_NAME: &str = "ps2_display";
@@ -57,13 +58,13 @@ fn install_fonts(ctx: &egui::Context) {
         .entry(FontFamily::Name(DISPLAY_FONT_NAME.into()))
         .or_default()
         .insert(0, DISPLAY_FONT_NAME.to_owned());
-    fonts
-        .families
-        .entry(FontFamily::Proportional)
-        .or_default()
-        .insert(0, DISPLAY_FONT_NAME.to_owned());
 
     ctx.set_fonts(fonts);
+}
+
+pub fn display_heading_text(ui: &egui::Ui, text: impl Into<String>) -> RichText {
+    let size = ui.style().text_styles[&TextStyle::Heading].size;
+    RichText::new(text).font(display_font(size))
 }
 
 fn apply_visuals(ctx: &egui::Context, palette: &Palette) {

--- a/crates/psu-packer-gui/src/ui/timestamps.rs
+++ b/crates/psu-packer-gui/src/ui/timestamps.rs
@@ -2,7 +2,7 @@ use chrono::{Local, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use eframe::egui;
 use egui_extras::DatePickerButton;
 
-use crate::{PackerApp, TimestampStrategy, TIMESTAMP_FORMAT};
+use crate::{ui::theme, PackerApp, TimestampStrategy, TIMESTAMP_FORMAT};
 
 pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.vertical(|ui| {
@@ -306,7 +306,7 @@ fn current_strategy_reason(
 pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
     app.timestamp_rules_ui.ensure_matches(&app.timestamp_rules);
 
-    ui.heading("Automatic timestamp rules");
+    ui.heading(theme::display_heading_text(ui, "Automatic timestamp rules"));
     ui.small("Adjust deterministic timestamp spacing, category order, and aliases.");
 
     if let Some(error) = &app.timestamp_rules_error {
@@ -361,7 +361,10 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
         });
 
     ui.add_space(12.0);
-    ui.heading("Category order and aliases");
+    ui.heading(theme::display_heading_text(
+        ui,
+        "Category order and aliases",
+    ));
     ui.small("Aliases map names without prefixes to their categories (one per line).");
     ui.add_space(6.0);
 


### PR DESCRIPTION
## Summary
- keep Orbitron scoped to the display font family and add a helper for pulling heading-sized display text
- update UI section headings to request the display font explicitly so body copy falls back to the proportional stack

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cb421c31188321bd7ce20a3f5502a2