### PR TITLE
Add pack confirmation workflow when required files are missing

### DIFF
--- a/crates/psu-packer-gui/src/ui/dialogs.rs
+++ b/crates/psu-packer-gui/src/ui/dialogs.rs
@@ -2,6 +2,29 @@ use eframe::egui;
 
 use crate::PackerApp;
 
+pub(crate) fn pack_confirmation(app: &mut PackerApp, ctx: &egui::Context) {
+    if let Some(missing) = app.pending_pack_missing_files() {
+        let message = PackerApp::format_missing_required_files_message(missing);
+        egui::Window::new("Confirm Packing")
+            .collapsible(false)
+            .resizable(false)
+            .show(ctx, |ui| {
+                ui.label(&message);
+                ui.add_space(12.0);
+                ui.label("Pack anyway?");
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Proceed").clicked() {
+                        app.confirm_pending_pack_action();
+                    }
+                    if ui.button("Go Back").clicked() {
+                        app.cancel_pending_pack_action();
+                    }
+                });
+            });
+    }
+}
+
 pub(crate) fn exit_confirmation(app: &mut PackerApp, ctx: &egui::Context) {
     if app.show_exit_confirm {
         egui::Window::new("Confirm Exit")


### PR DESCRIPTION
## Summary
- capture pending pack actions and missing file details so the GUI can confirm before proceeding
- update the packaging controls to queue pack jobs that need confirmation and surface a dialog to continue or cancel
- add regression tests that cover accepting or declining the confirmation flow

## Testing
- cargo test -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68cb5a3628708321adaba5619897f167