### PR TITLE
Expand PSU packer layout and increase text scale

### DIFF
--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -27,7 +27,8 @@ const ICON_SYS_UNSUPPORTED_CHAR_PLACEHOLDER: char = '\u{FFFD}';
 const TIMESTAMP_RULES_FILE: &str = "timestamp_rules.json";
 pub(crate) const REQUIRED_PROJECT_FILES: &[&str] =
     &["icon.icn", "icon.sys", "psu.toml", "title.cfg"];
-const CENTERED_COLUMN_MAX_WIDTH: f32 = 720.0;
+const CENTERED_COLUMN_MAX_WIDTH: f32 = 1180.0;
+const PACK_CONTROLS_TWO_COLUMN_MIN_WIDTH: f32 = 940.0;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum MissingFileReason {
@@ -2311,18 +2312,39 @@ impl eframe::App for PackerApp {
                                 }
 
                                 ui.add_space(8.0);
-                                ui::pack_controls::metadata_section(self, ui);
 
-                                if !showing_psu {
+                                let two_column_layout =
+                                    ui.available_width() >= PACK_CONTROLS_TWO_COLUMN_MIN_WIDTH;
+                                if two_column_layout {
+                                    ui.columns(2, |columns| {
+                                        columns[0].vertical(|ui| {
+                                            ui::pack_controls::metadata_section(self, ui);
+                                            ui.add_space(8.0);
+                                            ui::pack_controls::output_section(self, ui);
+                                        });
+
+                                        columns[1].vertical(|ui| {
+                                            if !showing_psu {
+                                                ui::pack_controls::file_filters_section(self, ui);
+                                                ui.add_space(8.0);
+                                            }
+                                            ui::pack_controls::packaging_section(self, ui);
+                                        });
+                                    });
+                                } else {
+                                    ui::pack_controls::metadata_section(self, ui);
+
+                                    if !showing_psu {
+                                        ui.add_space(8.0);
+                                        ui::pack_controls::file_filters_section(self, ui);
+                                    }
+
                                     ui.add_space(8.0);
-                                    ui::pack_controls::file_filters_section(self, ui);
+                                    ui::pack_controls::output_section(self, ui);
+
+                                    ui.add_space(8.0);
+                                    ui::pack_controls::packaging_section(self, ui);
                                 }
-
-                                ui.add_space(8.0);
-                                ui::pack_controls::output_section(self, ui);
-
-                                ui.add_space(8.0);
-                                ui::pack_controls::packaging_section(self, ui);
                             });
                         });
                     }

--- a/crates/psu-packer-gui/src/ui/mod.rs
+++ b/crates/psu-packer-gui/src/ui/mod.rs
@@ -12,13 +12,31 @@ pub(crate) fn centered_column<R>(
     max_width: f32,
     add_contents: impl FnOnce(&mut egui::Ui) -> R,
 ) -> R {
-    let width = ui.available_width().min(max_width);
-    ui.vertical_centered(|ui| {
-        ui.set_width(width);
-        ui.with_layout(egui::Layout::top_down(egui::Align::Center), |ui| {
-            add_contents(ui)
-        })
-        .inner
-    })
-    .inner
+    let available = ui.available_width();
+    let width = available.min(max_width);
+    let margin = ((available - width) * 0.5).max(0.0);
+
+    let mut result = None;
+    ui.horizontal(|ui| {
+        if margin > 0.0 {
+            ui.add_space(margin);
+        }
+
+        result = Some(
+            ui.scope(|ui| {
+                ui.set_width(width);
+                ui.with_layout(egui::Layout::top_down(egui::Align::Min), |ui| {
+                    add_contents(ui)
+                })
+                .inner
+            })
+            .inner,
+        );
+
+        if margin > 0.0 {
+            ui.add_space(margin);
+        }
+    });
+
+    result.expect("centered_column should always produce a result")
 }

--- a/crates/psu-packer-gui/src/ui/pack_controls.rs
+++ b/crates/psu-packer-gui/src/ui/pack_controls.rs
@@ -5,6 +5,7 @@ use eframe::egui;
 use crate::{ui::theme, PackerApp, SasPrefix, ICON_SYS_TITLE_CHAR_LIMIT};
 
 pub(crate) fn metadata_section(app: &mut PackerApp, ui: &mut egui::Ui) {
+    ui.set_width(ui.available_width());
     ui.group(|ui| {
         ui.heading(theme::display_heading_text(ui, "Metadata"));
         ui.small("Edit PSU metadata before or after selecting a folder.");
@@ -86,6 +87,7 @@ pub(crate) fn metadata_section(app: &mut PackerApp, ui: &mut egui::Ui) {
 }
 
 pub(crate) fn file_filters_section(app: &mut PackerApp, ui: &mut egui::Ui) {
+    ui.set_width(ui.available_width());
     ui.group(|ui| {
         ui.heading(theme::display_heading_text(ui, "File filters"));
         ui.small("Manage which files to include or exclude before creating the archive.");
@@ -138,6 +140,7 @@ pub(crate) fn file_filters_section(app: &mut PackerApp, ui: &mut egui::Ui) {
 }
 
 pub(crate) fn output_section(app: &mut PackerApp, ui: &mut egui::Ui) {
+    ui.set_width(ui.available_width());
     ui.group(|ui| {
         ui.heading(theme::display_heading_text(ui, "Output"));
         ui.small("Choose where the packed PSU file will be saved.");
@@ -163,6 +166,7 @@ pub(crate) fn output_section(app: &mut PackerApp, ui: &mut egui::Ui) {
 }
 
 pub(crate) fn packaging_section(app: &mut PackerApp, ui: &mut egui::Ui) {
+    ui.set_width(ui.available_width());
     ui.group(|ui| {
         ui.heading(theme::display_heading_text(ui, "Packaging"));
         ui.small("Validate the configuration and generate the PSU archive.");
@@ -173,7 +177,7 @@ pub(crate) fn packaging_section(app: &mut PackerApp, ui: &mut egui::Ui) {
             );
             ui.colored_label(egui::Color32::YELLOW, warning);
         }
-        ui.horizontal(|ui| {
+        ui.horizontal_wrapped(|ui| {
             let pack_button = ui
                 .add_enabled(!pack_in_progress, egui::Button::new("Pack PSU"))
                 .on_hover_text("Create the PSU archive using the settings above.");

--- a/crates/psu-packer-gui/src/ui/theme.rs
+++ b/crates/psu-packer-gui/src/ui/theme.rs
@@ -39,7 +39,10 @@ impl Default for Palette {
 pub fn install(ctx: &egui::Context, palette: &Palette) {
     install_fonts(ctx);
     apply_visuals(ctx, palette);
-    ctx.style_mut(|style| apply_spacing(style));
+    ctx.style_mut(|style| {
+        apply_text_styles(style);
+        apply_spacing(style);
+    });
 }
 
 pub fn display_font(size: f32) -> FontId {
@@ -90,6 +93,24 @@ fn apply_spacing(style: &mut Style) {
     style.spacing.window_margin = Margin::same(14);
     style.spacing.menu_margin = Margin::same(10);
     style.spacing.indent = 20.0;
+}
+
+fn apply_text_styles(style: &mut Style) {
+    style
+        .text_styles
+        .insert(TextStyle::Heading, FontId::proportional(28.0));
+    style
+        .text_styles
+        .insert(TextStyle::Body, FontId::proportional(18.0));
+    style
+        .text_styles
+        .insert(TextStyle::Button, FontId::proportional(18.0));
+    style
+        .text_styles
+        .insert(TextStyle::Small, FontId::proportional(15.0));
+    style
+        .text_styles
+        .insert(TextStyle::Monospace, FontId::monospace(16.0));
 }
 
 pub fn draw_vertical_gradient(


### PR DESCRIPTION
## Summary
- widen the centered workspace and allow a two-column packer layout on large viewports
- ensure packer sections expand to their columns and wrap action buttons for larger typography
- raise the default text style sizes in the GUI theme for more legible text

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68cb6817e4d483219a3e4572670de381