### PR TITLE
Add PSU Packer icon to GUI window

### DIFF
--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -14,6 +14,7 @@ egui_extras = { version = "0.31.1", features = ["chrono"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
+image = { version = "0.25.6", features = ["ico"] }
 
 [build-dependencies]
 winresource = "0.1"

--- a/crates/psu-packer-gui/src/main.rs
+++ b/crates/psu-packer-gui/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use eframe::{egui, NativeOptions, Renderer};
+use eframe::{egui, egui::IconData, NativeOptions, Renderer};
 use psu_packer_gui::PackerApp;
 use std::any::Any;
 use std::fmt;
@@ -37,12 +37,37 @@ fn shared_native_options() -> NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([1024.0, 768.0])
             .with_min_inner_size([640.0, 480.0])
+            .with_icon(load_app_icon())
             .with_resizable(true),
         ..Default::default()
     };
 
     options.centered = true;
     options
+}
+
+fn load_app_icon() -> IconData {
+    let icon = include_bytes!("../../suitcase/assets/psupackergui.ico");
+    match image::load_from_memory(icon) {
+        Ok(image) => {
+            let image = image.into_rgba8();
+            let (width, height) = image.dimensions();
+
+            IconData {
+                rgba: image.into_raw(),
+                width,
+                height,
+            }
+        }
+        Err(error) => {
+            eprintln!("Failed to load icon: {error}");
+            IconData {
+                rgba: vec![0; 4],
+                width: 1,
+                height: 1,
+            }
+        }
+    }
 }
 
 fn run_app(options: NativeOptions) -> eframe::Result<()> {


### PR DESCRIPTION
## Summary
- load the PSU Packer icon into the GUI viewport builder so Windows shows the custom app icon
- add the `image` dependency to decode the ICO asset at startup

## Testing
- cargo build -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68cb7ed2694c832186a8c81694210ac5