### PR TITLE
Add exit confirmation when closing GUI

### DIFF
--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -348,6 +348,7 @@ pub struct PackerApp {
     pub(crate) loaded_psu_path: Option<PathBuf>,
     pub(crate) loaded_psu_files: Vec<String>,
     pub(crate) show_exit_confirm: bool,
+    pub(crate) exit_confirmed: bool,
     pub(crate) source_present_last_frame: bool,
     pub(crate) icon_sys_enabled: bool,
     pub(crate) icon_sys_title_line1: String,
@@ -441,6 +442,7 @@ impl Default for PackerApp {
             loaded_psu_path: None,
             loaded_psu_files: Vec::new(),
             show_exit_confirm: false,
+            exit_confirmed: false,
             source_present_last_frame: false,
             icon_sys_enabled: false,
             icon_sys_title_line1: String::new(),
@@ -2145,6 +2147,12 @@ fn text_editor_ui(
 impl eframe::App for PackerApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.poll_pack_job();
+
+        if ctx.input(|i| i.viewport().close_requested()) && !self.exit_confirmed {
+            self.exit_confirmed = false;
+            self.show_exit_confirm = true;
+            ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
+        }
 
         self.zoom_factor = self.zoom_factor.clamp(0.5, 2.0);
         ctx.set_pixels_per_point(self.zoom_factor);

--- a/crates/psu-packer-gui/src/ui/dialogs.rs
+++ b/crates/psu-packer-gui/src/ui/dialogs.rs
@@ -38,9 +38,11 @@ pub(crate) fn exit_confirmation(app: &mut PackerApp, ctx: &egui::Context) {
                     let no_clicked = ui.button("No").clicked();
 
                     if yes_clicked {
+                        app.exit_confirmed = true;
                         app.show_exit_confirm = false;
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                     } else if no_clicked {
+                        app.exit_confirmed = false;
                         app.show_exit_confirm = false;
                     }
                 });

--- a/crates/psu-packer-gui/src/ui/file_picker.rs
+++ b/crates/psu-packer-gui/src/ui/file_picker.rs
@@ -91,6 +91,7 @@ fn file_menu_contents(
 
     if ui.button("Exit").clicked() {
         app.show_exit_confirm = true;
+        app.exit_confirmed = false;
         ui.close_menu();
     }
 }


### PR DESCRIPTION
## Summary
- add state to cancel OS close requests until the user confirms exiting the GUI
- ensure the exit confirmation dialog and File → Exit option use the shared confirmation flow

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68cb8179c130832188a9546b2338b472