### PR TITLE
Ensure psu.toml is never packed

### DIFF
--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -2020,7 +2020,10 @@ mod packer_app_tests {
             .expect("export succeeds");
 
         assert_eq!(exported_root, export_parent.join("APP_SAVE"));
-        assert!(exported_root.join("psu.toml").exists());
+        assert!(
+            !exported_root.join("psu.toml").exists(),
+            "psu.toml should not be embedded in exported PSUs"
+        );
         assert!(exported_root.join("title.cfg").exists());
         assert!(exported_root.join("icon.icn").exists());
         assert!(exported_root.join("EXTRA.BIN").exists());

--- a/crates/psu-packer/src/lib.rs
+++ b/crates/psu-packer/src/lib.rs
@@ -785,7 +785,13 @@ fn filter_files(files: &[PathBuf]) -> Vec<PathBuf> {
     files
         .iter()
         .filter_map(|f| {
-            if !f.is_file() {
+            if f.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.eq_ignore_ascii_case("psu.toml"))
+                .unwrap_or(false)
+            {
+                None
+            } else if !f.is_file() {
                 println!(
                     "{} {}",
                     f.display().to_string().dimmed(),

--- a/crates/psu-packer/tests/exclude_psu_toml.rs
+++ b/crates/psu-packer/tests/exclude_psu_toml.rs
@@ -1,0 +1,63 @@
+use std::fs;
+use std::path::Path;
+
+use ps2_filetypes::{PSUEntryKind, PSU};
+use psu_packer::{pack_with_config, Config};
+use tempfile::tempdir;
+
+fn write_file(path: &Path, contents: &[u8]) {
+    fs::write(path, contents).expect("write file");
+}
+
+fn packed_psu_contains_file(output: &Path, name: &str) -> bool {
+    let data = fs::read(output).expect("read packed psu");
+    let archive = PSU::new(data);
+    archive.entries.iter().any(|entry| {
+        matches!(entry.kind, PSUEntryKind::File) && entry.name.eq_ignore_ascii_case(name)
+    })
+}
+
+#[test]
+fn psu_toml_is_never_packed() {
+    let workspace = tempdir().expect("temp dir");
+    let project = workspace.path();
+
+    write_file(&project.join("DATA.BIN"), b"payload");
+    write_file(&project.join("psu.toml"), b"[config]\nname = \"Test\"\n");
+
+    let config_include_all = Config {
+        name: "Test Save".to_string(),
+        timestamp: None,
+        include: None,
+        exclude: None,
+        icon_sys: None,
+    };
+    let output_include_all = project.join("include-all.psu");
+    pack_with_config(project, &output_include_all, config_include_all)
+        .expect("pack with automatic include");
+
+    assert!(
+        packed_psu_contains_file(&output_include_all, "DATA.BIN"),
+        "expected data file to be present"
+    );
+    assert!(
+        !packed_psu_contains_file(&output_include_all, "psu.toml"),
+        "psu.toml should always be omitted"
+    );
+
+    let config_with_explicit_include = Config {
+        name: "Test Save".to_string(),
+        timestamp: None,
+        include: Some(vec!["DATA.BIN".to_string(), "psu.toml".to_string()]),
+        exclude: None,
+        icon_sys: None,
+    };
+    let output_with_explicit = project.join("explicit.psu");
+    pack_with_config(project, &output_with_explicit, config_with_explicit_include)
+        .expect("pack with explicit include");
+
+    assert!(
+        !packed_psu_contains_file(&output_with_explicit, "psu.toml"),
+        "psu.toml should be filtered even when explicitly included"
+    );
+}


### PR DESCRIPTION
## Summary
- always filter psu.toml out of the packer inputs and cover the behavior with a new integration test
- ensure the GUI-generated configuration mirrors that behavior and update related tests and expectations

## Testing
- cargo test -p psu-packer
- cargo test -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68cb8ac92354832195a792b05215f5f6