### PR TITLE
Adjust input background visuals

### DIFF
--- a/crates/psu-packer-gui/src/ui/theme.rs
+++ b/crates/psu-packer-gui/src/ui/theme.rs
@@ -9,6 +9,7 @@ pub const DISPLAY_FONT_NAME: &str = "ps2_display";
 pub struct Palette {
     pub background: Color32,
     pub panel: Color32,
+    pub input_background: Color32,
     pub header_top: Color32,
     pub header_bottom: Color32,
     pub footer_top: Color32,
@@ -24,6 +25,7 @@ impl Default for Palette {
         Self {
             background: Color32::from_rgb(6, 8, 20),
             panel: Color32::from_rgb(18, 38, 52),
+            input_background: Color32::from_rgb(32, 58, 78),
             header_top: Color32::from_rgb(12, 16, 40),
             header_bottom: Color32::from_rgb(60, 40, 120),
             footer_top: Color32::from_rgb(16, 30, 52),
@@ -73,13 +75,13 @@ pub fn display_heading_text(ui: &egui::Ui, text: impl Into<String>) -> RichText 
 fn apply_visuals(ctx: &egui::Context, palette: &Palette) {
     let mut visuals = egui::Visuals::dark();
     visuals.override_text_color = Some(palette.text_primary);
-    visuals.widgets.noninteractive.bg_fill = palette.panel;
+    visuals.widgets.noninteractive.bg_fill = palette.input_background.gamma_multiply(0.9);
     visuals.widgets.noninteractive.fg_stroke.color = palette.text_primary;
-    visuals.widgets.inactive.bg_fill = palette.panel;
+    visuals.widgets.inactive.bg_fill = palette.input_background;
     visuals.widgets.inactive.fg_stroke.color = palette.text_primary;
-    visuals.widgets.hovered.bg_fill = palette.soft_accent.gamma_multiply(0.2);
-    visuals.widgets.active.bg_fill = palette.soft_accent.gamma_multiply(0.3);
-    visuals.widgets.open.bg_fill = palette.panel;
+    visuals.widgets.hovered.bg_fill = palette.soft_accent.gamma_multiply(0.22);
+    visuals.widgets.active.bg_fill = palette.soft_accent.gamma_multiply(0.32);
+    visuals.widgets.open.bg_fill = palette.input_background.gamma_multiply(0.95);
     visuals.extreme_bg_color = palette.background;
     visuals.faint_bg_color = palette.background;
     visuals.panel_fill = palette.background;


### PR DESCRIPTION
## Summary
- add a dedicated `input_background` color to the GUI palette
- update widget visuals to use the lighter input color and tweak hover/active fills for contrast

## Testing
- cargo build -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68cb9a1a4d3c83219df899a6983e13e7