### PR TITLE
Use encoding_rs for Shift-JIS titles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,6 +1245,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,6 +3185,7 @@ dependencies = [
  "base64 0.22.1",
  "byteorder",
  "chrono",
+ "encoding_rs",
  "image",
  "indexmap",
  "toml 0.9.5",

--- a/crates/ps2-filetypes/Cargo.toml
+++ b/crates/ps2-filetypes/Cargo.toml
@@ -8,6 +8,7 @@ byteorder = "1.5.0"
 chrono = "0.4.40"
 image = "0.25.6"
 indexmap = "2.10.0"
+encoding_rs = "0.8"
 toml = "0.9.2"
 
 [dev-dependencies]

--- a/crates/ps2-filetypes/src/common/sjis.rs
+++ b/crates/ps2-filetypes/src/common/sjis.rs
@@ -1,71 +1,32 @@
-pub fn encode_sjis(input: &str) -> Vec<u8> {
-    input
-        .as_bytes()
-        .iter()
-        .flat_map(|b| match *b {
-            b' ' => [0x80, 0x3F],
-            b':' => [0x81, 0x46],
-            b'/' => [0x81, 0x5E],
-            b'(' => [0x81, 0x69],
-            b')' => [0x81, 0x6A],
-            b'[' => [0x81, 0x6D],
-            b']' => [0x81, 0x6E],
-            b'{' => [0x81, 0x6F],
-            b'}' => [0x81, 0x70],
-            48..=90 => [0x82, *b + 31],
-            97..=122 => [0x82, *b + 32],
-            _ => [0x00, 0x00],
-        })
-        .collect::<Vec<_>>()
+use encoding_rs::SHIFT_JIS;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SjisEncodeError {
+    UnmappableCharacter,
+}
+
+pub fn encode_sjis(input: &str) -> Result<Vec<u8>, SjisEncodeError> {
+    let (encoded, _, had_errors) = SHIFT_JIS.encode(input);
+    if had_errors {
+        return Err(SjisEncodeError::UnmappableCharacter);
+    }
+
+    Ok(encoded.into_owned())
 }
 
 pub fn decode_sjis(input: &[u8]) -> String {
-    let mut str_out = Vec::with_capacity(input.len());
+    let (decoded, _, _) = SHIFT_JIS.decode(input);
+    decoded.into_owned()
+}
 
-    for pair in input.chunks_exact(2) {
-        match pair[0] {
-            0x00 => {
-                if pair[1] == 0x00 {
-                    str_out.push(b'\0');
-                } else {
-                    str_out.push(b'?');
-                }
-            }
-            0x0D => match pair[1] {
-                0x0A => {
-                    str_out.push(b'\r');
-                    str_out.push(b'\n');
-                }
-                0x00 => str_out.push(b'\r'),
-                _ => str_out.push(b'?'),
-            },
-            0x0A => match pair[1] {
-                0x00 => str_out.push(b'\n'),
-                _ => str_out.push(b'?'),
-            },
-            0x81 => match pair[1] {
-                0x40 => str_out.push(b' '),
-                0x46 => str_out.push(b':'),
-                0x5E => str_out.push(b'/'),
-                0x69 => str_out.push(b'('),
-                0x6A => str_out.push(b')'),
-                0x6D => str_out.push(b'['),
-                0x6E => str_out.push(b']'),
-                0x6F => str_out.push(b'{'),
-                0x70 => str_out.push(b'}'),
-                _ => str_out.push(b'?'),
-            },
-            0x82 => match pair[1] {
-                0x4f..=0x7A => str_out.push(pair[1] - 31),
-                0x81..=0x99 => str_out.push(pair[1] - 32),
-                0x3F => str_out.push(b' '),
-                _ => str_out.push(b'?'),
-            },
-            _ => str_out.push(b'?'),
-        };
+pub fn is_roundtrip_sjis(value: &str) -> bool {
+    let (encoded, _, encode_errors) = SHIFT_JIS.encode(value);
+    if encode_errors {
+        return false;
     }
 
-    String::from_utf8_lossy(&str_out).to_string()
+    let (decoded, _, decode_errors) = SHIFT_JIS.decode(&encoded);
+    !decode_errors && decoded == value
 }
 
 #[cfg(test)]
@@ -89,5 +50,33 @@ mod tests {
     #[test]
     fn decode_lf_only() {
         assert_decodes_to([0x0A, 0x00], "\n");
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_ascii_punctuation() {
+        let input = "SAVE!&LOAD";
+        let encoded = encode_sjis(input).expect("encode ASCII punctuation");
+        let decoded = decode_sjis(&encoded);
+
+        assert_eq!(decoded, input);
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_multibyte_japanese() {
+        let input = "セーブテスト";
+        let encoded = encode_sjis(input).expect("encode Japanese text");
+        let decoded = decode_sjis(&encoded);
+
+        assert_eq!(decoded, input);
+    }
+
+    #[test]
+    fn reports_unmappable_characters() {
+        assert!(matches!(
+            encode_sjis("𝄞"),
+            Err(SjisEncodeError::UnmappableCharacter)
+        ));
+        assert!(!is_roundtrip_sjis("𝄞"));
+        assert!(is_roundtrip_sjis("テスト"));
     }
 }

--- a/crates/ps2-filetypes/src/parser/icon_sys.rs
+++ b/crates/ps2-filetypes/src/parser/icon_sys.rs
@@ -102,7 +102,12 @@ impl IconSys {
 
         bytes.extend_from_slice(&self.ambient_color.to_bytes());
 
-        let title_bytes = encode_sjis(&self.title);
+        let title_bytes = encode_sjis(&self.title).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Title contains characters that cannot be encoded as Shift-JIS",
+            )
+        })?;
         let title_len = title_bytes.len();
         if title_len > 68 {
             return Err(std::io::Error::new(

--- a/crates/ps2-filetypes/tests/icon_sys.rs
+++ b/crates/ps2-filetypes/tests/icon_sys.rs
@@ -1,13 +1,15 @@
 use base64::{engine::general_purpose::STANDARD, Engine};
 use ps2_filetypes::{color::Color, IconSys};
 
-#[test]
-fn parses_and_roundtrips_icon_sys_background_colors() {
+fn icon_sys_fixture_bytes() -> Vec<u8> {
     let encoded = include_str!("fixtures/icon_sys.b64");
     let encoded: String = encoded.split_whitespace().collect();
-    let bytes = STANDARD
-        .decode(encoded)
-        .expect("decode icon.sys fixture");
+    STANDARD.decode(encoded).expect("decode icon.sys fixture")
+}
+
+#[test]
+fn parses_and_roundtrips_icon_sys_background_colors() {
+    let bytes = icon_sys_fixture_bytes();
     let icon_sys = IconSys::new(bytes.clone());
 
     let expected = [
@@ -28,4 +30,20 @@ fn parses_and_roundtrips_icon_sys_background_colors() {
         .expect("serialize icon.sys back to bytes");
 
     assert_eq!(encoded_bytes, bytes);
+}
+
+#[test]
+fn icon_sys_roundtrips_shift_jis_title() {
+    let bytes = icon_sys_fixture_bytes();
+    let mut icon_sys = IconSys::new(bytes);
+    icon_sys.title = "SAVE!&テスト".to_string();
+    icon_sys.linebreak_pos = "SAVE!&".chars().count() as u16;
+
+    let serialized = icon_sys
+        .to_bytes()
+        .expect("serialize icon.sys with Shift-JIS title");
+    let reparsed = IconSys::new(serialized);
+
+    assert_eq!(reparsed.title, "SAVE!&テスト");
+    assert_eq!(reparsed.linebreak_pos, icon_sys.linebreak_pos);
 }

--- a/crates/psu-packer-gui/src/ui/pack_controls.rs
+++ b/crates/psu-packer-gui/src/ui/pack_controls.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use eframe::egui;
 
 use crate::{ui::theme, PackerApp, SasPrefix, ICON_SYS_TITLE_CHAR_LIMIT};
+use ps2_filetypes::sjis;
 
 pub(crate) fn metadata_section(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.set_width(ui.available_width());
@@ -650,12 +651,13 @@ impl PackerApp {
                 ));
             }
             let title_is_valid = |value: &str| {
-                value
-                    .chars()
-                    .all(|c| c.is_ascii() && (!c.is_ascii_control() || c == ' '))
+                !value.chars().any(|c| c.is_control()) && sjis::is_roundtrip_sjis(value)
             };
             if !title_is_valid(line1) || !title_is_valid(line2) {
-                return Err("Icon.sys titles only support printable ASCII characters".to_string());
+                return Err(
+                    "Icon.sys titles must contain characters representable in Shift-JIS"
+                        .to_string(),
+                );
             }
 
             let has_content = line1.chars().any(|c| !c.is_whitespace())


### PR DESCRIPTION
## Summary
- replace the manual Shift-JIS tables with `encoding_rs`, expose a round-trip helper, and add unit coverage for punctuation and Japanese titles
- ensure `IconSys::to_bytes` surfaces encoding failures and add a regression test that round-trips punctuation and multibyte characters
- allow the GUI icon.sys inputs to accept any Shift-JIS round-trippable characters and update validation messaging
- add the `encoding_rs` dependency to ps2-filetypes

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68cbeffefb348321bd0cae8216ad8a85