### PR TITLE
Implement metadata-driven title.cfg editor

### DIFF
--- a/crates/ps2-filetypes/title_cfg.toml
+++ b/crates/ps2-filetypes/title_cfg.toml
@@ -36,9 +36,12 @@ hint = "Homebrew"
 
 [Description]
 tooltip = "A short description of the app. Must be less than 255 characters or it will be truncated in OPL."
+char_limit = 255
+multiline = true
 
 [Notes]
 tooltip = "A free text field. Not used in most cases."
+multiline = true
 
 [source]
 tooltip = "The url of the project. It can be a git repository, forum thread, website of the app, etc."


### PR DESCRIPTION
## Summary
- replace the title.cfg text editor with a metadata-driven form that renders widgets from the helper schema and keeps editor state in sync
- add form metadata for description and notes fields (char limits and multiline hints)
- expose TitleCfg::missing_mandatory_fields and refactor validation/tests to reuse it

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cc04e673508321828b760f439c1b2e