### PR TITLE
Gate psu.toml editor UI behind feature flag

### DIFF
--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -4,6 +4,11 @@ edition.workspace = true
 license.workspace = true
 version.workspace = true
 
+[features]
+default = []
+# Re-enable the psu.toml editor UI with `--features psu-toml-editor`.
+psu-toml-editor = []
+
 [dependencies]
 psu-packer = { path = "../psu-packer" }
 ps2-filetypes = { path = "../ps2-filetypes" }

--- a/crates/psu-packer-gui/src/ui/file_picker.rs
+++ b/crates/psu-packer-gui/src/ui/file_picker.rs
@@ -42,13 +42,16 @@ fn file_menu_contents(
         ui.close_menu();
     }
 
-    let edit_psu_response = ui.button("Edit psu.toml");
-    if let Some(recorder) = recorder.as_mut() {
-        recorder.record(FileMenuItem::EditPsuToml, edit_psu_response.enabled());
-    }
-    if edit_psu_response.clicked() {
-        app.open_psu_toml_tab();
-        ui.close_menu();
+    #[cfg(feature = "psu-toml-editor")]
+    {
+        let edit_psu_response = ui.button("Edit psu.toml");
+        if let Some(recorder) = recorder.as_mut() {
+            recorder.record(FileMenuItem::EditPsuToml, edit_psu_response.enabled());
+        }
+        if edit_psu_response.clicked() {
+            app.open_psu_toml_tab();
+            ui.close_menu();
+        }
     }
 
     let edit_title_response = ui.button("Edit title.cfg");
@@ -69,13 +72,16 @@ fn file_menu_contents(
         ui.close_menu();
     }
 
-    let create_psu_response = ui.button("Create psu.toml from template");
-    if let Some(recorder) = recorder.as_mut() {
-        recorder.record(FileMenuItem::CreatePsuToml, create_psu_response.enabled());
-    }
-    if create_psu_response.clicked() {
-        app.create_psu_toml_from_template();
-        ui.close_menu();
+    #[cfg(feature = "psu-toml-editor")]
+    {
+        let create_psu_response = ui.button("Create psu.toml from template");
+        if let Some(recorder) = recorder.as_mut() {
+            recorder.record(FileMenuItem::CreatePsuToml, create_psu_response.enabled());
+        }
+        if create_psu_response.clicked() {
+            app.create_psu_toml_from_template();
+            ui.close_menu();
+        }
     }
 
     let create_title_response = ui.button("Create title.cfg from template");
@@ -102,9 +108,11 @@ fn file_menu_contents(
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum FileMenuItem {
     PackPsu,
+    #[cfg_attr(not(feature = "psu-toml-editor"), allow(dead_code))]
     EditPsuToml,
     EditTitleCfg,
     EditIconSys,
+    #[cfg_attr(not(feature = "psu-toml-editor"), allow(dead_code))]
     CreatePsuToml,
     CreateTitleCfg,
 }
@@ -135,10 +143,16 @@ mod tests {
         let _ = ctx.end_frame();
 
         assert!(recorder.is_enabled(FileMenuItem::PackPsu));
+        #[cfg(feature = "psu-toml-editor")]
         assert!(recorder.is_enabled(FileMenuItem::EditPsuToml));
+        #[cfg(not(feature = "psu-toml-editor"))]
+        assert!(!recorder.has_entry(FileMenuItem::EditPsuToml));
         assert!(recorder.is_enabled(FileMenuItem::EditTitleCfg));
         assert!(recorder.is_enabled(FileMenuItem::EditIconSys));
+        #[cfg(feature = "psu-toml-editor")]
         assert!(recorder.is_enabled(FileMenuItem::CreatePsuToml));
+        #[cfg(not(feature = "psu-toml-editor"))]
+        assert!(!recorder.has_entry(FileMenuItem::CreatePsuToml));
         assert!(recorder.is_enabled(FileMenuItem::CreateTitleCfg));
     }
 
@@ -150,6 +164,10 @@ mod tests {
     impl RecordingMenuRecorder {
         fn is_enabled(&self, item: FileMenuItem) -> bool {
             *self.entries.get(&item).unwrap_or(&false)
+        }
+
+        fn has_entry(&self, item: FileMenuItem) -> bool {
+            self.entries.contains_key(&item)
         }
     }
 

--- a/crates/psu-packer-gui/src/ui/pack_controls.rs
+++ b/crates/psu-packer-gui/src/ui/pack_controls.rs
@@ -77,6 +77,7 @@ pub(crate) fn metadata_section(app: &mut PackerApp, ui: &mut egui::Ui) {
             app.metadata_inputs_changed(previous_default_output);
         }
 
+        #[cfg(feature = "psu-toml-editor")]
         if app.folder.is_some() && app.psu_toml_sync_blocked {
             ui.add_space(6.0);
             ui.colored_label(
@@ -237,8 +238,8 @@ impl ListKind {
 mod tests {
     use super::*;
     use chrono::NaiveDate;
-    use std::path::PathBuf;
     use ps2_filetypes::sjis;
+    use std::path::PathBuf;
 
     #[test]
     fn config_from_state_appends_psu_toml_once() {
@@ -338,9 +339,7 @@ mod tests {
 
         let config = app.config_from_state().expect("configuration should build");
         let icon_sys = config.icon_sys.expect("icon_sys configuration present");
-        let expected_break = sjis::encode_sjis(&app.icon_sys_title_line1)
-            .unwrap()
-            .len() as u16;
+        let expected_break = sjis::encode_sjis(&app.icon_sys_title_line1).unwrap().len() as u16;
 
         assert_eq!(icon_sys.linebreak_pos, Some(expected_break));
     }
@@ -710,8 +709,7 @@ impl PackerApp {
 
         let icon_sys = if self.icon_sys_enabled && !self.icon_sys_use_existing {
             let encoded_line1 = sjis::encode_sjis(&self.icon_sys_title_line1).map_err(|_| {
-                "Icon.sys titles must contain characters representable in Shift-JIS"
-                    .to_string()
+                "Icon.sys titles must contain characters representable in Shift-JIS".to_string()
             })?;
             let linebreak_pos = encoded_line1.len() as u16;
             let combined_title =
@@ -748,6 +746,7 @@ impl PackerApp {
         })
     }
 
+    #[cfg(feature = "psu-toml-editor")]
     pub(crate) fn refresh_psu_toml_editor(&mut self) {
         if self.folder.is_none() {
             self.psu_toml_sync_blocked = false;
@@ -776,5 +775,10 @@ impl PackerApp {
                 self.psu_toml_sync_blocked = true;
             }
         }
+    }
+
+    #[cfg(not(feature = "psu-toml-editor"))]
+    pub(crate) fn refresh_psu_toml_editor(&mut self) {
+        self.psu_toml_sync_blocked = false;
     }
 }


### PR DESCRIPTION
## Summary
- add an optional `psu-toml-editor` feature and hide the psu.toml EditorTab when it is disabled
- gate the tab UI, menu items, and supporting helpers so the editor state is retained without showing the psu.toml editor by default
- conditionally compile psu.toml-specific tests and menu assertions to match the new feature flag

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cc21c969e483219add76b3fcbd10e2