### PR TITLE
Refresh GUI palette and panel styling

### DIFF
--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -2605,20 +2605,27 @@ impl eframe::App for PackerApp {
                         ui.label(
                             egui::RichText::new("Packing PSU…")
                                 .font(theme::display_font(26.0))
-                                .color(self.theme.neon_accent),
+                                .color(self.theme.text_primary),
                         );
                         ui.add_space(8.0);
                         ui.add(
                             egui::ProgressBar::new(progress)
                                 .desired_width(200.0)
-                                .animate(true),
+                                .animate(true)
+                                .fill(self.theme.neon_accent),
                         );
                     });
                 });
         }
 
         egui::TopBottomPanel::top("top_panel")
-            .frame(egui::Frame::none().fill(self.theme.background))
+            .frame(
+                egui::Frame::new()
+                    .inner_margin(egui::Margin::same(0))
+                    .outer_margin(egui::Margin::same(0))
+                    .fill(self.theme.panel)
+                    .stroke(egui::Stroke::NONE),
+            )
             .show(ctx, |ui| {
                 let rect = ui.max_rect();
                 theme::draw_vertical_gradient(
@@ -2655,7 +2662,13 @@ impl eframe::App for PackerApp {
             });
 
         egui::CentralPanel::default()
-            .frame(egui::Frame::none().fill(self.theme.background))
+            .frame(
+                egui::Frame::new()
+                    .inner_margin(egui::Margin::same(0))
+                    .outer_margin(egui::Margin::same(0))
+                    .fill(self.theme.panel)
+                    .stroke(egui::Stroke::NONE),
+            )
             .show(ctx, |ui| {
                 let rect = ui.max_rect();
                 theme::draw_vertical_gradient(

--- a/crates/psu-packer-gui/src/ui/theme.rs
+++ b/crates/psu-packer-gui/src/ui/theme.rs
@@ -23,17 +23,17 @@ pub struct Palette {
 impl Default for Palette {
     fn default() -> Self {
         Self {
-            background: Color32::from_rgb(2, 0, 14),
-            panel: Color32::from_rgb(1, 0, 7),
-            input_background: Color32::from_rgb(28, 28, 48),
-            header_top: Color32::from_rgb(2, 0, 14),
-            header_bottom: Color32::from_rgb(10, 0, 54),
-            footer_top: Color32::from_rgb(2, 0, 14),
-            footer_bottom: Color32::from_rgb(10, 0, 54),
-            neon_accent: Color32::from_rgb(110, 0, 255),
-            soft_accent: Color32::from_rgb(72, 64, 128),
-            separator: Color32::from_rgb(110, 0, 255),
-            text_primary: Color32::from_rgb(214, 220, 240),
+            background: Color32::from_rgb(9, 12, 24),
+            panel: Color32::from_rgb(18, 22, 36),
+            input_background: Color32::from_rgb(28, 34, 52),
+            header_top: Color32::from_rgb(14, 18, 32),
+            header_bottom: Color32::from_rgb(30, 40, 64),
+            footer_top: Color32::from_rgb(18, 24, 38),
+            footer_bottom: Color32::from_rgb(34, 46, 70),
+            neon_accent: Color32::from_rgb(32, 120, 212),
+            soft_accent: Color32::from_rgb(64, 104, 176),
+            separator: Color32::from_rgb(40, 54, 84),
+            text_primary: Color32::from_rgb(224, 230, 244),
         }
     }
 }
@@ -75,20 +75,23 @@ pub fn display_heading_text(ui: &egui::Ui, text: impl Into<String>) -> RichText 
 fn apply_visuals(ctx: &egui::Context, palette: &Palette) {
     let mut visuals = egui::Visuals::dark();
     visuals.override_text_color = Some(palette.text_primary);
-    visuals.widgets.noninteractive.bg_fill = palette.input_background;
+    visuals.widgets.noninteractive.bg_fill = palette.panel;
     visuals.widgets.noninteractive.fg_stroke.color = palette.text_primary;
     visuals.widgets.inactive.bg_fill = palette.input_background;
     visuals.widgets.inactive.fg_stroke.color = palette.text_primary;
-    visuals.widgets.hovered.bg_fill = palette.soft_accent;
-    visuals.widgets.active.bg_fill = palette.neon_accent.gamma_multiply(0.7);
-    visuals.widgets.open.bg_fill = palette.input_background;
+    visuals.widgets.hovered.bg_fill = palette.soft_accent.gamma_multiply(0.8);
+    visuals.widgets.hovered.fg_stroke.color = palette.text_primary;
+    visuals.widgets.active.bg_fill = palette.neon_accent.gamma_multiply(0.85);
+    visuals.widgets.active.fg_stroke.color = palette.text_primary;
+    visuals.widgets.open.bg_fill = palette.panel;
     visuals.extreme_bg_color = palette.background;
     visuals.faint_bg_color = palette.background;
     visuals.panel_fill = palette.panel;
     visuals.window_fill = palette.panel;
-    visuals.window_stroke.color = palette.neon_accent;
-    visuals.window_shadow.color = palette.neon_accent;
-    visuals.popup_shadow.color = palette.neon_accent;
+    visuals.window_stroke.color = palette.separator;
+    visuals.hyperlink_color = palette.neon_accent;
+    visuals.selection.bg_fill = palette.neon_accent.gamma_multiply(0.75);
+    visuals.selection.stroke.color = palette.neon_accent;
 
     ctx.set_visuals(visuals);
 }


### PR DESCRIPTION
## Summary
- refresh the GUI palette with deeper navy backgrounds, layered panels, and PS2-inspired accent blues
- update egui visuals to align hover, active, and selection states with the revised palette and simplify window strokes
- retune packer progress, panels, and gradients to ensure legible text and accents across the refreshed theme

## Testing
- cargo check -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68ccb0e5c0048321a3ea8d382b07e4f8