### PR TITLE
Refine metadata layout and timestamp controls

### DIFF
--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -2781,18 +2781,19 @@ impl eframe::App for PackerApp {
 
                                 let two_column_layout =
                                     ui.available_width() >= PACK_CONTROLS_TWO_COLUMN_MIN_WIDTH;
+                                let section_gap = 12.0;
                                 if two_column_layout {
                                     ui.columns(2, |columns| {
                                         columns[0].vertical(|ui| {
                                             ui::pack_controls::metadata_section(self, ui);
-                                            ui.add_space(8.0);
+                                            ui.add_space(section_gap);
                                             ui::pack_controls::output_section(self, ui);
                                         });
 
                                         columns[1].vertical(|ui| {
                                             if !showing_psu {
                                                 ui::pack_controls::file_filters_section(self, ui);
-                                                ui.add_space(8.0);
+                                                ui.add_space(section_gap);
                                             }
                                             ui::pack_controls::packaging_section(self, ui);
                                         });
@@ -2801,14 +2802,14 @@ impl eframe::App for PackerApp {
                                     ui::pack_controls::metadata_section(self, ui);
 
                                     if !showing_psu {
-                                        ui.add_space(8.0);
+                                        ui.add_space(section_gap);
                                         ui::pack_controls::file_filters_section(self, ui);
                                     }
 
-                                    ui.add_space(8.0);
+                                    ui.add_space(section_gap);
                                     ui::pack_controls::output_section(self, ui);
 
-                                    ui.add_space(8.0);
+                                    ui.add_space(section_gap);
                                     ui::pack_controls::packaging_section(self, ui);
                                 }
                             });

--- a/crates/psu-packer-gui/src/ui/pack_controls.rs
+++ b/crates/psu-packer-gui/src/ui/pack_controls.rs
@@ -55,11 +55,20 @@ pub(crate) fn metadata_section(app: &mut PackerApp, ui: &mut egui::Ui) {
                     metadata_changed = true;
                 }
                 ui.end_row();
+            });
 
-                ui.label("Timestamp");
-                crate::ui::timestamps::metadata_timestamp_section(app, ui);
-                ui.end_row();
+        ui.add_space(10.0);
+        ui.label(egui::RichText::new("Timestamp").strong());
+        ui.add_space(6.0);
+        if crate::ui::timestamps::metadata_timestamp_section(app, ui) {
+            metadata_changed = true;
+        }
 
+        ui.add_space(8.0);
+        egui::Grid::new("metadata_icon_grid")
+            .num_columns(2)
+            .spacing(egui::vec2(12.0, 6.0))
+            .show(ui, |ui| {
                 ui.label("icon.sys");
                 let mut label = "Configure icon.sys metadata in the dedicated tab.".to_string();
                 if app.icon_sys_enabled {


### PR DESCRIPTION
## Summary
- keep the metadata grid for prefix and file name inputs while introducing a dedicated timestamp block and aligned icon.sys note
- refresh the metadata timestamp card with concise guidance, consistent spacing, and change detection signaling back to the metadata section
- normalize spacing between packer sections so the new timestamp card lines up in both single- and two-column layouts

## Testing
- cargo fmt
- cargo test -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68ccd0ea8e7c8321acf5f096685a1f9e