### PR TITLE
Enable psu.toml editor by default

### DIFF
--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -5,8 +5,8 @@ license.workspace = true
 version.workspace = true
 
 [features]
-default = []
-# Re-enable the psu.toml editor UI with `--features psu-toml-editor`.
+default = ["psu-toml-editor"]
+# The psu.toml editor UI is enabled by default; disable with `--no-default-features` if needed.
 psu-toml-editor = []
 
 [dependencies]

--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -262,7 +262,7 @@ impl Default for TimestampStrategy {
 enum EditorTab {
     PsuSettings,
     #[cfg(feature = "psu-toml-editor")]
-    /// Enable the psu.toml editor again with `--features psu-toml-editor`.
+    /// psu.toml editor tab (enabled by default; disable with `--no-default-features`).
     PsuToml,
     TitleCfg,
     IconSys,


### PR DESCRIPTION
## Summary
- enable the `psu-toml-editor` feature by default for the GUI crate so the editor tab is available without extra flags
- update inline documentation to clarify the tab is now included by default

## Testing
- cargo run -p psu-packer-gui *(fails: requires a windowing environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd887d5748321ade05a7c9394d511