### PR TITLE
Update SAS timestamp scheduling to new anchor rules

### DIFF
--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -2918,6 +2918,7 @@ mod tests {
         app.psu_toml_editor.modified = true;
 
         let ctx = egui::Context::default();
+        crate::ui::theme::install(&ctx, &app.theme);
 
         let _ = ctx.run(Default::default(), |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {

--- a/crates/psu-packer-gui/src/ui/timestamps.rs
+++ b/crates/psu-packer-gui/src/ui/timestamps.rs
@@ -288,21 +288,16 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
         .spacing(egui::vec2(12.0, 6.0))
         .show(ui, |ui| {
             ui.label("Seconds between items");
-            let mut seconds = app.timestamp_rules.seconds_between_items.max(2);
+            let mut seconds = app.timestamp_rules.seconds_between_items.max(1);
             if ui
                 .add(
                     egui::DragValue::new(&mut seconds)
-                        .clamp_range(2..=3600)
+                        .clamp_range(1..=3600)
                         .speed(1.0),
                 )
                 .changed()
             {
-                let mut coerced = if seconds % 2 == 0 {
-                    seconds
-                } else {
-                    seconds + 1
-                };
-                coerced = coerced.clamp(2, 3600);
+                let coerced = seconds.clamp(1, 3600);
                 if app.timestamp_rules.seconds_between_items != coerced {
                     app.timestamp_rules.seconds_between_items = coerced;
                     app.mark_timestamp_rules_modified();


### PR DESCRIPTION
## Summary
- use 1-second spacing and 86,400 slots per category in SAS timestamp rules
- anchor deterministic timestamps to the fixed 2099-01-01T07:59:59Z base with FNV-derived nudges
- allow 1-second spacing in the GUI editor and install fonts in GUI tests for stability

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cd9acd08148321bb4b3e2d639dedd1