### PR TITLE
Enable glow renderer fallback

### DIFF
--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -5,9 +5,10 @@ license.workspace = true
 version.workspace = true
 
 [features]
-default = ["psu-toml-editor"]
+default = ["psu-toml-editor", "glow"]
 # The psu.toml editor UI is enabled by default; disable with `--no-default-features` if needed.
 psu-toml-editor = []
+glow = ["eframe/glow"]
 
 [dependencies]
 psu-packer = { path = "../psu-packer" }

--- a/crates/psu-packer-gui/build.rs
+++ b/crates/psu-packer-gui/build.rs
@@ -4,6 +4,12 @@ use {
 };
 
 fn main() -> io::Result<()> {
+    println!("cargo:rustc-check-cfg=cfg(feature, values(\"eframe/glow\"))");
+
+    if env::var_os("CARGO_FEATURE_GLOW").is_some() {
+        println!("cargo:rustc-cfg=feature=\"eframe/glow\"");
+    }
+
     if env::var_os("CARGO_CFG_WINDOWS").is_some() {
         WindowsResource::new()
             .set_icon("../suitcase/assets/icon.ico")

--- a/crates/psu-packer-gui/src/main.rs
+++ b/crates/psu-packer-gui/src/main.rs
@@ -14,13 +14,17 @@ fn main() -> eframe::Result<()> {
         Err(wgpu_error) => {
             report_renderer_error("WGPU", &wgpu_error);
 
-            let glow_result = run_app_with_renderer(Renderer::Glow);
-            match glow_result {
-                Ok(result) => Ok(result),
-                Err(glow_error) => {
-                    report_renderer_error("Glow", &glow_error);
-                    Err(wgpu_error)
+            if cfg!(feature = "eframe/glow") {
+                let glow_result = run_app_with_renderer(Renderer::Glow);
+                match glow_result {
+                    Ok(result) => Ok(result),
+                    Err(glow_error) => {
+                        report_renderer_error("Glow", &glow_error);
+                        Err(wgpu_error)
+                    }
                 }
+            } else {
+                Err(wgpu_error)
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a crate feature that enables eframe's glow renderer by default alongside the existing wgpu support
- guard the runtime fallback so glow is only attempted when the feature is available and teach the build script about the extra cfg

## Testing
- cargo build -p psu-packer-gui --features glow
- cargo build -p psu-packer-gui --no-default-features
- timeout 5 cargo run -p psu-packer-gui --features glow


------
https://chatgpt.com/codex/tasks/task_e_68cda81326908321b37241579545bde2