### PR TITLE
Forward glow feature to eframe

### DIFF
--- a/crates/suitcase/Cargo.toml
+++ b/crates/suitcase/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [features]
 default = ["glow", "wgpu"]
-glow = []
+glow = ["eframe/glow"]
 wgpu = ["eframe/wgpu"]
 
 [dependencies]
 macros = { path = "../macros" }
-eframe = { version = "0.31.1", features = ["default", "persistence"] }
+eframe = { version = "0.31.1", default-features = false, features = ["persistence"] }
 egui_extras = { version = "0.31.1", features = ["svg", "image"] }
 egui_dock = "0.16.0"
 cgmath = "0.18.0"


### PR DESCRIPTION
## Summary
- forward the suitcase crate's `glow` feature to `eframe/glow` and gate eframe defaults
- disable eframe default features so the crate features choose the renderer backend

## Testing
- cargo build --no-default-features --features glow
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68ce04d116308321bb7ad1262f0cc113