### PR TITLE
Cache title.cfg parsing results in GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,12 +3232,14 @@ dependencies = [
  "eframe",
  "egui_extras",
  "image",
+ "indexmap",
  "ps2-filetypes",
  "psu-packer",
  "rfd 0.14.1",
  "serde",
  "serde_json",
  "tempfile",
+ "toml 0.9.5",
  "winresource",
 ]
 

--- a/crates/psu-packer-gui/Cargo.toml
+++ b/crates/psu-packer-gui/Cargo.toml
@@ -20,6 +20,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 image = { version = "0.25.6", features = ["ico"] }
+indexmap = "2"
+toml = "0.9.2"
 
 [build-dependencies]
 winresource = "0.1"


### PR DESCRIPTION
## Summary
- add a cached `TitleCfg` with helper accessors on `TextFileEditor`
- update the title.cfg form to reuse the cached data and avoid reparsing on every frame
- reuse the cached metadata in validation tests and add the supporting dependencies

## Testing
- cargo test -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68d0a6316684832187e129a0558679a1