### PR TITLE
Add live project asset checklist and enforce new requirements

### DIFF
--- a/crates/psu-packer-gui/src/ui/file_picker.rs
+++ b/crates/psu-packer-gui/src/ui/file_picker.rs
@@ -6,7 +6,10 @@ use std::{
 use eframe::egui;
 use ps2_filetypes::{IconSys, PSUEntryKind, PSU};
 
-use crate::{ui::theme, PackerApp, SasPrefix, TimestampStrategy};
+use crate::{
+    ui::{project_requirements_checklist, theme},
+    PackerApp, SasPrefix, TimestampStrategy, REQUIRED_PROJECT_FILES,
+};
 
 pub(crate) fn file_menu(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.menu_button("File", |ui| {
@@ -181,7 +184,10 @@ mod tests {
 pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.group(|ui| {
         ui.heading(theme::display_heading_text(ui, "Folder"));
-        ui.small("Select the PSU project folder containing psu.toml.");
+        ui.small(format!(
+            "Select the PSU project folder containing these assets: {}.",
+            REQUIRED_PROJECT_FILES.join(", ")
+        ));
         ui.horizontal(|ui| {
             let spacing = ui.spacing().item_spacing.x;
             ui.spacing_mut().item_spacing.x = spacing.max(8.0);
@@ -214,11 +220,10 @@ pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
 
         if let Some(folder) = &app.folder {
             ui.label(format!("Folder: {}", folder.display()));
-            if !app.missing_required_project_files.is_empty() {
-                let warning = PackerApp::format_missing_required_files_message(
-                    &app.missing_required_project_files,
-                );
-                ui.colored_label(egui::Color32::YELLOW, warning);
+            if let Some(statuses) = app.project_requirement_statuses() {
+                ui.add_space(4.0);
+                ui.small("Required project asset checklist:");
+                project_requirements_checklist(ui, &statuses);
             }
         }
     });

--- a/crates/psu-packer-gui/src/ui/mod.rs
+++ b/crates/psu-packer-gui/src/ui/mod.rs
@@ -1,5 +1,7 @@
 use eframe::egui;
 
+use crate::{MissingRequiredFile, ProjectRequirementStatus};
+
 pub mod dialogs;
 pub mod file_picker;
 pub mod icon_sys;
@@ -39,4 +41,48 @@ pub(crate) fn centered_column<R>(
     });
 
     result.expect("centered_column should always produce a result")
+}
+
+fn requirement_description(file: &MissingRequiredFile) -> String {
+    match file.reason.detail() {
+        Some(detail) => format!("{} ({detail})", file.name),
+        None => file.name.clone(),
+    }
+}
+
+pub(crate) fn project_requirements_checklist(
+    ui: &mut egui::Ui,
+    requirements: &[ProjectRequirementStatus],
+) {
+    if requirements.is_empty() {
+        return;
+    }
+
+    let original_spacing = ui.spacing().item_spacing.y;
+    let adjusted_spacing = original_spacing.max(4.0);
+    ui.spacing_mut().item_spacing.y = adjusted_spacing;
+
+    for status in requirements {
+        let description = requirement_description(&status.file);
+        let mut satisfied = status.satisfied;
+        let text = if status.satisfied {
+            egui::RichText::new(description)
+        } else {
+            egui::RichText::new(description).color(egui::Color32::YELLOW)
+        };
+        let response = ui.add_enabled(false, egui::Checkbox::new(&mut satisfied, text));
+        if status.satisfied {
+            response.on_hover_text("Requirement satisfied.");
+        } else {
+            let mut tooltip = String::from("Missing from the selected project folder.");
+            if let Some(detail) = status.file.reason.detail() {
+                tooltip.push(' ');
+                tooltip.push_str(detail);
+                tooltip.push('.');
+            }
+            response.on_hover_text(tooltip);
+        }
+    }
+
+    ui.spacing_mut().item_spacing.y = original_spacing;
 }


### PR DESCRIPTION
## Summary
- require the new PSU project assets (`list.icn`, `copy.icn`, `del.icn`, `title.cfg`, `icon.sys`) and expose requirement satisfaction data for the UI and tests
- replace the warning banner with live checklists in the folder and packaging sections while keeping pack/update/export buttons disabled until all requirements pass
- add a shared checklist renderer so tooltips and status rows stay in sync as assets appear or disappear

## Testing
- `cargo test -p psu-packer-gui`


------
https://chatgpt.com/codex/tasks/task_e_68d1e80290108321a3d4a81ffde64015