### PR TITLE
Share SAS metadata via JSON artifact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3197,8 +3197,10 @@ dependencies = [
  "argh",
  "chrono",
  "colored",
+ "once_cell",
  "ps2-filetypes",
  "serde",
+ "serde_json",
  "tempfile",
  "toml 0.9.5",
 ]

--- a/crates/psu-packer/Cargo.toml
+++ b/crates/psu-packer/Cargo.toml
@@ -9,9 +9,11 @@ version.workspace = true
 ps2-filetypes = { path = "../ps2-filetypes" }
 toml = "0.9.5"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 argh = { version = "0.1.13" }
 chrono = "0.4.42"
 colored = "3.0.0"
+once_cell = "1.19.0"
 
 [dev-dependencies]
 tempfile = "3.14.0"

--- a/crates/psu-packer/src/sas_data.json
+++ b/crates/psu-packer/src/sas_data.json
@@ -1,0 +1,22 @@
+{
+  "charset": " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-.",
+  "defaults": {
+    "seconds_between_items": 2,
+    "slots_per_category": 43200
+  },
+  "categories": [
+    { "key": "APP_", "aliases": ["OSDXMB", "XEBPLUS"] },
+    { "key": "APPS", "aliases": [] },
+    { "key": "PS1_", "aliases": [] },
+    { "key": "EMU_", "aliases": [] },
+    { "key": "GME_", "aliases": [] },
+    { "key": "DST_", "aliases": [] },
+    { "key": "DBG_", "aliases": [] },
+    { "key": "RAA_", "aliases": ["RESTART", "POWEROFF"] },
+    { "key": "RTE_", "aliases": ["NEUTRINO"] },
+    { "key": "DEFAULT", "aliases": [] },
+    { "key": "SYS_", "aliases": ["BOOT"] },
+    { "key": "ZZY_", "aliases": ["EXPLOITS"] },
+    { "key": "ZZZ_", "aliases": ["BM", "MATRIXTEAM", "OPL"] }
+  ]
+}


### PR DESCRIPTION
## Summary
- centralize SAS timestamp defaults, aliases, and charset in `sas_data.json` and load it from `sas.rs`
- update the `sas_timestamps.py` utility to consume the shared JSON instead of hard-coded tables
- add a regression test to round-trip the shared data so the CLI stays aligned with the script

## Testing
- cargo test -p psu-packer

------
https://chatgpt.com/codex/tasks/task_e_68d26705ede88321bf53ed1190e8e5d7