### PR TITLE
Handle missing birth times when packing

### DIFF
--- a/crates/psu-packer/tests/timestamp.rs
+++ b/crates/psu-packer/tests/timestamp.rs
@@ -3,11 +3,27 @@ use std::path::Path;
 
 use chrono::{NaiveDate, NaiveDateTime};
 use ps2_filetypes::{PSUEntryKind, PSU};
-use psu_packer::{pack_with_config, Config};
+use psu_packer::{
+    pack_with_config, pack_with_config_and_metadata_reader, Config, FileTimes, MetadataReader,
+};
 use tempfile::tempdir;
 
 fn create_sample_file(path: &Path) {
     fs::write(path, b"example").expect("write sample file");
+}
+
+#[derive(Default)]
+struct UnsupportedCreatedMetadata;
+
+impl MetadataReader for UnsupportedCreatedMetadata {
+    fn file_times(&self, path: &Path) -> std::io::Result<FileTimes> {
+        let metadata = fs::metadata(path)?;
+        let modified = metadata.modified()?;
+        Ok(FileTimes {
+            created: None,
+            modified,
+        })
+    }
 }
 
 #[test]
@@ -75,4 +91,38 @@ fn pack_with_or_without_timestamp_controls_entry_times() {
 
     let file_timestamp = file_timestamp.expect("file entry present");
     assert_ne!(file_timestamp, NaiveDateTime::default());
+}
+
+#[test]
+fn pack_without_birth_time_support_falls_back_to_modified_time() {
+    let tempdir = tempdir().expect("temp dir");
+    let folder = tempdir.path();
+    let source_file = folder.join("DATA.BIN");
+    create_sample_file(&source_file);
+    let output_dir = folder.join("output");
+    fs::create_dir(&output_dir).expect("create output dir");
+
+    let config = Config {
+        name: "Test Save".to_string(),
+        timestamp: None,
+        include: None,
+        exclude: None,
+        icon_sys: None,
+    };
+
+    let metadata_reader = UnsupportedCreatedMetadata::default();
+    let output = output_dir.join("fallback.psu");
+
+    pack_with_config_and_metadata_reader(folder, &output, config, &metadata_reader)
+        .expect("pack without birth time support");
+
+    let packed = PSU::new(fs::read(&output).expect("read output"));
+    let file_entry = packed
+        .entries
+        .iter()
+        .find(|entry| matches!(entry.kind, PSUEntryKind::File))
+        .expect("file entry present");
+
+    assert_eq!(file_entry.created, file_entry.modified);
+    assert_ne!(file_entry.created, NaiveDateTime::default());
 }


### PR DESCRIPTION
## Summary
- add a metadata reader abstraction that falls back to modified times when creation times are unavailable
- update PSU packing to use the new abstraction and expose a helper for custom metadata readers
- add an integration test that verifies packing succeeds when creation times are unsupported

## Testing
- cargo test -p psu-packer

------
https://chatgpt.com/codex/tasks/task_e_68d26f0ed6688321873ceda3c7c8db9c