### PR TITLE
Document experimental memcard crate

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ PS2Suitcase is a Rust toolchain for building, inspecting, and packaging PlayStat
 - **`suitcase` (PS2Suitcase GUI):** Full-featured desktop app with project workspaces, live validation, icon/sys editors, and PSU export workflows.
 - **`psu-packer` (CLI):** Standalone packer that reads `psu.toml`, regenerates `icon.sys` when requested, and writes deterministic `.psu` archives.
 - **`psu-packer-gui`:** Lightweight GUI wrapper around the packer for quick folder selection and metadata edits when the full PS2Suitcase interface is unnecessary.
-- **Libraries:** `ps2-filetypes` (parsers and writers for PSU, ICON, and TITLE files) and `memcard` (memory-card utilities under active refactor), plus shared UI macros.
+- **Libraries:** `ps2-filetypes` (parsers and writers for PSU, ICON, and TITLE files) and `memcard` (an experimental memory-card toolkit kept in-tree for future features), plus shared UI macros.
 - **Packaging tooling:** `xtask-build-app` bundles the PS2Suitcase GUI into a macOS `.app` structure with the correct resources.
 
 ## Feature highlights
@@ -92,6 +92,15 @@ This windowed utility mirrors the CLI packer with a simplified layout for quick 
    ```
    This writes `build/PSU Builder.app/` with the executable, icon, and `Info.plist`. Codesign and notarise as required for distribution.
 4. Include sample templates from `assets/templates/` in your distribution package so users can scaffold new projects quickly.
+
+## Workspace maintenance
+
+- Every crate under `crates/` should either ship in the released tooling or be
+  explicitly marked as experimental. If a package becomes unused, remove it from
+  the workspace to keep `cargo` builds predictable.
+- Run `cargo metadata --format-version 1` during CI or local checks after adding
+  or removing crates. This ensures the workspace manifest stays in sync with the
+  directories on disk and flags missing members early.
 
 ## Configuration (`psu.toml`)
 

--- a/crates/memcard/Cargo.toml
+++ b/crates/memcard/Cargo.toml
@@ -3,6 +3,7 @@ name = "memcard"
 edition.workspace = true
 license.workspace = true
 version.workspace = true
+publish = false
 
 [dependencies]
 byteorder = "1.5.0"

--- a/crates/memcard/src/lib.rs
+++ b/crates/memcard/src/lib.rs
@@ -1,3 +1,10 @@
+//! Experimental utilities for exploring the PS2 memory-card FAT.
+//!
+//! The code in this crate is an early-stage refactor that currently powers only
+//! internal experiments and example binaries. It intentionally stays in the
+//! workspace so the APIs can iterate alongside the rest of the toolchain
+//! without being published to crates.io.
+
 pub mod dir_entry;
 pub mod fat;
 


### PR DESCRIPTION
## Summary
- mark the experimental memcard crate as non-publishable and document its current status
- refresh the top-level README to note memcard’s experimental role and add workspace maintenance guidance

## Testing
- cargo check -p memcard

------
https://chatgpt.com/codex/tasks/task_e_68d27cef240883219b5831db8969346f