### PR TITLE
Refactor PackerApp to wrap shared PackerState

### DIFF
--- a/crates/psu-packer-gui/src/ui/dialogs.rs
+++ b/crates/psu-packer-gui/src/ui/dialogs.rs
@@ -3,7 +3,7 @@ use eframe::egui;
 use crate::PackerApp;
 
 pub(crate) fn pack_confirmation(app: &mut PackerApp, ctx: &egui::Context) {
-    if let Some(missing) = app.pending_pack_missing_files() {
+    if let Some(missing) = app.packer_state.pending_pack_missing_files() {
         let message = PackerApp::format_missing_required_files_message(missing);
         egui::Window::new("Confirm Packing")
             .collapsible(false)


### PR DESCRIPTION
## Summary
- add a packer_state field to PackerApp and delegate helper methods to the shared gui-core state
- update dialogs, file picker, pack controls, timestamps, and view modules to consume the shared state accessors
- adjust tests and helpers to reference packer_state and keep only UI-specific data in PackerApp

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d30ee0a82c83219f95bc0e0ffb18b1