### PR TITLE
Use shared pack job types from gui-core

### DIFF
--- a/crates/psu-packer-gui/src/lib.rs
+++ b/crates/psu-packer-gui/src/lib.rs
@@ -4,9 +4,9 @@ pub mod ui;
 pub mod view;
 
 pub use gui_core::state::{
-    MissingFileReason, MissingRequiredFile, ProjectRequirementStatus, SasPrefix,
-    TimestampRulesUiState, TimestampStrategy, REQUIRED_PROJECT_FILES, TIMESTAMP_FORMAT,
-    TIMESTAMP_RULES_FILE,
+    MissingFileReason, MissingRequiredFile, PackJob, PackOutcome, PackPreparation, PackProgress,
+    PendingPackAction, ProjectRequirementStatus, SasPrefix, TimestampRulesUiState,
+    TimestampStrategy, REQUIRED_PROJECT_FILES, TIMESTAMP_FORMAT, TIMESTAMP_RULES_FILE,
 };
 pub use psu_packer::ICON_SYS_TITLE_CHAR_LIMIT;
 pub use state::PackerApp;

--- a/crates/psu-packer-gui/src/state.rs
+++ b/crates/psu-packer-gui/src/state.rs
@@ -1014,7 +1014,7 @@ mod packer_app_tests {
     use tempfile::tempdir;
 
     fn wait_for_pack_completion(app: &mut PackerApp) {
-        while app.packer_state.pack_job.is_some() {
+        while app.pack_job_active() {
             thread::sleep(Duration::from_millis(10));
             app.poll_pack_job();
         }
@@ -1143,10 +1143,7 @@ mod packer_app_tests {
             app.test_pack_job_started,
             "pack job should start after acceptance"
         );
-        assert!(
-            app.packer_state.pack_job.is_some(),
-            "pack job handle should be created"
-        );
+        assert!(app.pack_job_active(), "pack job handle should be created");
 
         wait_for_pack_completion(&mut app);
     }
@@ -1171,7 +1168,7 @@ mod packer_app_tests {
 
         app.handle_update_psu_request();
 
-        assert!(app.packer_state.pack_job.is_some(), "pack job should start");
+        assert!(app.pack_job_active(), "pack job should start");
         wait_for_pack_completion(&mut app);
 
         assert!(
@@ -1205,10 +1202,7 @@ mod packer_app_tests {
 
         app.handle_update_psu_request();
 
-        assert!(
-            app.packer_state.pack_job.is_none(),
-            "pack job should not start"
-        );
+        assert!(!app.pack_job_active(), "pack job should not start");
         let message = app
             .packer_state
             .error_message
@@ -1244,7 +1238,7 @@ mod packer_app_tests {
 
         app.handle_update_psu_request();
 
-        assert!(app.packer_state.pack_job.is_some(), "pack job should start");
+        assert!(app.pack_job_active(), "pack job should start");
         assert_ne!(
             app.packer_state.error_message.as_deref(),
             Some("Please select a folder"),


### PR DESCRIPTION
## Summary
- re-export the shared pack job types from `gui-core` for `psu-packer-gui`
- update packer app tests to use the shared pack job accessors instead of local definitions

## Testing
- cargo fmt
- cargo test -p psu-packer-gui

------
https://chatgpt.com/codex/tasks/task_e_68d3181e9ec483219376ccf53aec834b