### PR TITLE
Refactor UI modules to dispatch actions

### DIFF
--- a/crates/gui-core/src/actions.rs
+++ b/crates/gui-core/src/actions.rs
@@ -1,3 +1,4 @@
+use chrono::NaiveDateTime;
 use egui::{Button, Context, KeyboardShortcut, Ui, WidgetText};
 
 use crate::state::SasPrefix;
@@ -41,6 +42,7 @@ pub enum TimestampAction {
     SyncAfterSourceUpdate,
     ApplyPlannedTimestamp,
     ResetRulesToDefault,
+    SetManualTimestamp(Option<NaiveDateTime>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -54,6 +56,7 @@ pub enum FileListAction {
     Browse(FileListKind),
     ManualAdd(FileListKind),
     RemoveSelected(FileListKind),
+    SelectEntry(FileListKind, Option<usize>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -69,6 +72,7 @@ pub enum IconSysAction {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Action {
     OpenProject,
+    SelectProjectFolder,
     PackPsu,
     UpdatePsu,
     ExportPsuToFolder,
@@ -79,6 +83,14 @@ pub enum Action {
     CreateMetadataTemplate(MetadataTarget),
     OpenSettings,
     OpenEditor(EditorAction),
+    ZoomIn,
+    ZoomOut,
+    ResetZoom,
+    ConfirmPack,
+    CancelPack,
+    ShowExitConfirmation,
+    ConfirmExit,
+    CancelExit,
     Metadata(MetadataAction),
     Timestamp(TimestampAction),
     FileList(FileListAction),

--- a/crates/gui-core/src/state.rs
+++ b/crates/gui-core/src/state.rs
@@ -1797,6 +1797,9 @@ impl ActionDispatcher for AppState {
                 TimestampAction::ResetRulesToDefault => {
                     self.packer.reset_timestamp_rules_to_default();
                 }
+                TimestampAction::SetManualTimestamp(timestamp) => {
+                    self.packer.set_manual_timestamp(timestamp);
+                }
             },
             Action::FileList(file_action) => match file_action {
                 FileListAction::Browse(kind) => {
@@ -1816,6 +1819,9 @@ impl ActionDispatcher for AppState {
                     if let Some(index) = self.packer.file_list_selection(kind) {
                         self.packer.remove_file_list_entry(kind, index);
                     }
+                }
+                FileListAction::SelectEntry(kind, selection) => {
+                    self.packer.select_file_list_entry(kind, selection);
                 }
             },
             Action::IconSys(icon_action) => match icon_action {

--- a/crates/psu-packer-gui/src/ui/dialogs.rs
+++ b/crates/psu-packer-gui/src/ui/dialogs.rs
@@ -1,6 +1,8 @@
 use eframe::egui;
 
 use crate::PackerApp;
+use gui_core::actions::Action;
+use gui_core::ActionDispatcher;
 
 pub(crate) fn pack_confirmation(app: &mut PackerApp, ctx: &egui::Context) {
     if let Some(missing) = app.packer_state.pending_pack_missing_files() {
@@ -15,10 +17,10 @@ pub(crate) fn pack_confirmation(app: &mut PackerApp, ctx: &egui::Context) {
                 ui.add_space(8.0);
                 ui.horizontal(|ui| {
                     if ui.button("Proceed").clicked() {
-                        app.confirm_pending_pack_action();
+                        app.trigger_action(Action::ConfirmPack);
                     }
                     if ui.button("Go Back").clicked() {
-                        app.cancel_pending_pack_action();
+                        app.trigger_action(Action::CancelPack);
                     }
                 });
             });
@@ -38,12 +40,10 @@ pub(crate) fn exit_confirmation(app: &mut PackerApp, ctx: &egui::Context) {
                     let no_clicked = ui.button("No").clicked();
 
                     if yes_clicked {
-                        app.exit_confirmed = true;
-                        app.show_exit_confirm = false;
+                        app.trigger_action(Action::ConfirmExit);
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                     } else if no_clicked {
-                        app.exit_confirmed = false;
-                        app.show_exit_confirm = false;
+                        app.trigger_action(Action::CancelExit);
                     }
                 });
             });

--- a/crates/psu-packer-gui/src/ui/file_picker.rs
+++ b/crates/psu-packer-gui/src/ui/file_picker.rs
@@ -93,11 +93,8 @@ fn file_menu_contents(
 
     ui.separator();
 
-    if ui.button("Exit").clicked() {
-        app.show_exit_confirm = true;
-        app.exit_confirmed = false;
-        ui.close_menu();
-    }
+    let exit_descriptor = ActionDescriptor::new(Action::ShowExitConfirmation, "Exit");
+    actions::action_button(ui, app, &exit_descriptor);
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -184,30 +181,15 @@ pub(crate) fn folder_section(app: &mut PackerApp, ui: &mut egui::Ui) {
             let spacing = ui.spacing().item_spacing.x;
             ui.spacing_mut().item_spacing.x = spacing.max(8.0);
 
-            if ui
-                .button("Select folder")
-                .on_hover_text("Pick the source directory to load configuration values.")
-                .clicked()
-            {
-                if let Some(folder) = rfd::FileDialog::new().pick_folder() {
-                    load_project_files(app, &folder);
-                    if app.icon_sys_enabled {
-                        app.open_icon_sys_tab();
-                    } else {
-                        app.open_psu_settings_tab();
-                    }
-                }
-            }
+            let select_folder_descriptor =
+                ActionDescriptor::new(Action::SelectProjectFolder, "Select folder");
+            actions::action_button(ui, app, &select_folder_descriptor)
+                .on_hover_text("Pick the source directory to load configuration values.");
 
-            if ui
-                .button("Load PSU...")
-                .on_hover_text(
-                    "Open an existing PSU archive to populate the editor from its metadata.",
-                )
-                .clicked()
-            {
-                app.handle_open_psu();
-            }
+            let open_psu_descriptor = ActionDescriptor::new(Action::OpenProject, "Load PSU...");
+            actions::action_button(ui, app, &open_psu_descriptor).on_hover_text(
+                "Open an existing PSU archive to populate the editor from its metadata.",
+            );
         });
 
         if let Some(folder) = &app.packer_state.folder {

--- a/crates/psu-packer-gui/src/view/mod.rs
+++ b/crates/psu-packer-gui/src/view/mod.rs
@@ -4,6 +4,8 @@ use crate::{
     state::{self, EditorTab, PackerApp},
     ui::{self, theme},
 };
+use gui_core::actions::{self, Action, ActionDescriptor};
+use gui_core::ActionDispatcher;
 
 pub trait View<TState> {
     fn show(&mut self, ui: &mut egui::Ui, state: &mut TState);
@@ -23,8 +25,7 @@ impl eframe::App for PackerApp {
         self.poll_pack_job();
 
         if ctx.input(|i| i.viewport().close_requested()) && !self.exit_confirmed {
-            self.exit_confirmed = false;
-            self.show_exit_confirm = true;
+            self.trigger_action(Action::ShowExitConfirmation);
             ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
         }
 
@@ -78,18 +79,12 @@ impl eframe::App for PackerApp {
                 egui::menu::bar(ui, |ui| {
                     ui::file_picker::file_menu(self, ui);
                     ui.menu_button("View", |ui| {
-                        if ui.button("Zoom In").clicked() {
-                            self.zoom_factor = (self.zoom_factor + 0.1).min(2.0);
-                            ui.close_menu();
-                        }
-                        if ui.button("Zoom Out").clicked() {
-                            self.zoom_factor = (self.zoom_factor - 0.1).max(0.5);
-                            ui.close_menu();
-                        }
-                        if ui.button("Reset Zoom").clicked() {
-                            self.zoom_factor = 1.0;
-                            ui.close_menu();
-                        }
+                        let zoom_in = ActionDescriptor::new(Action::ZoomIn, "Zoom In");
+                        actions::action_button(ui, self, &zoom_in);
+                        let zoom_out = ActionDescriptor::new(Action::ZoomOut, "Zoom Out");
+                        actions::action_button(ui, self, &zoom_out);
+                        let reset_zoom = ActionDescriptor::new(Action::ResetZoom, "Reset Zoom");
+                        actions::action_button(ui, self, &reset_zoom);
                     });
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.add_space(12.0);


### PR DESCRIPTION
## Summary
- Added new `Action` variants (e.g., `SelectProjectFolder`, zoom controls, confirm/cancel flows) and handled them inside `PackerApp::trigger_action`, moving configuration builders (`ensure_output_destination_selected`, `build_config`, etc.) from `ui/pack_controls.rs` into `state.rs`. Updated `gui-core` dispatcher to cover `TimestampAction::SetManualTimestamp` and `FileListAction::SelectEntry`.  
  ↳ Files: `crates/gui-core/src/actions.rs`, `crates/gui-core/src/state.rs`, `crates/psu-packer-gui/src/state.rs`  
- Refactored UI modules to dispatch actions instead of mutating state directly (`pack_controls`, `icon_sys`, `timestamps`, `dialogs`, `file_picker`, and `view`). Added imports for `ActionDispatcher` where needed and rewired menu/toolbar interactions to go through action descriptors.  
  ↳ Files: `crates/psu-packer-gui/src/ui/{pack_controls.rs,icon_sys.rs,timestamps.rs,dialogs.rs,file_picker.rs}`, `crates/psu-packer-gui/src/view/mod.rs`
- Added new unit tests covering zoom/exit actions and updated existing tests to use action descriptors after API changes. Tests currently run (`cargo test -p psu-packer-gui`).

## Testing
- `cargo test -p psu-packer-gui`


------
https://chatgpt.com/codex/tasks/task_e_68d425de0a0c8321bdb0a868a3dec18f