### PR TITLE
Route icon.sys and timestamp UI updates through action dispatchers

### DIFF
--- a/crates/gui-core/src/actions.rs
+++ b/crates/gui-core/src/actions.rs
@@ -35,7 +35,20 @@ pub enum TimestampStrategyAction {
     Manual,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TimestampRulesAction {
+    SetSecondsBetweenItems(u32),
+    SetSlotsPerCategory(u32),
+    MoveCategoryUp(usize),
+    MoveCategoryDown(usize),
+    SetAliasSelected {
+        category_index: usize,
+        alias: String,
+        selected: bool,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum TimestampAction {
     SelectStrategy(TimestampStrategyAction),
     RefreshFromStrategy,
@@ -43,6 +56,7 @@ pub enum TimestampAction {
     ApplyPlannedTimestamp,
     ResetRulesToDefault,
     SetManualTimestamp(Option<NaiveDateTime>),
+    Rules(TimestampRulesAction),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -59,7 +73,7 @@ pub enum FileListAction {
     SelectEntry(FileListKind, Option<usize>),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum IconSysAction {
     Enable,
     Disable,
@@ -67,6 +81,7 @@ pub enum IconSysAction {
     GenerateNew,
     ClearPreset,
     ResetFields,
+    ApplyPreset(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/psu-packer-gui/src/ui/timestamps.rs
+++ b/crates/psu-packer-gui/src/ui/timestamps.rs
@@ -3,8 +3,20 @@ use eframe::egui;
 use egui_extras::DatePickerButton;
 
 use crate::{ui::theme, PackerApp, TimestampStrategy, TIMESTAMP_FORMAT};
-use gui_core::actions::{Action, TimestampAction, TimestampStrategyAction};
+use gui_core::actions::{Action, TimestampAction, TimestampRulesAction, TimestampStrategyAction};
 use gui_core::ActionDispatcher;
+
+fn dispatch_timestamp_action(app: &mut PackerApp, action: TimestampAction) -> bool {
+    let wrapped = Action::Timestamp(action);
+    if !app.supports_action(wrapped.clone()) {
+        return false;
+    }
+    if !app.is_action_enabled(wrapped.clone()) {
+        return false;
+    }
+    app.trigger_action(wrapped);
+    true
+}
 
 pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.vertical(|ui| {
@@ -40,11 +52,12 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                         && app.packer_state.timestamp_strategy != TimestampStrategy::None
                         && strategy == TimestampStrategy::None
                     {
-                        app.trigger_action(Action::Timestamp(
+                        dispatch_timestamp_action(
+                            app,
                             TimestampAction::SelectStrategy(
                                 TimestampStrategyAction::None,
                             ),
-                        ));
+                        );
                     }
                 });
                 ui.label("• Use when verifying contents does not require metadata timestamps.");
@@ -69,11 +82,12 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                         && app.packer_state.timestamp_strategy != TimestampStrategy::InheritSource
                         && strategy == TimestampStrategy::InheritSource
                     {
-                        app.trigger_action(Action::Timestamp(
+                        dispatch_timestamp_action(
+                            app,
                             TimestampAction::SelectStrategy(
                                 TimestampStrategyAction::InheritSource,
                             ),
-                        ));
+                        );
                     }
                 });
                 ui.label("• Use when the loaded source already contains a trusted timestamp.");
@@ -104,11 +118,12 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                         && app.packer_state.timestamp_strategy != TimestampStrategy::SasRules
                         && strategy == TimestampStrategy::SasRules
                     {
-                        app.trigger_action(Action::Timestamp(
+                        dispatch_timestamp_action(
+                            app,
                             TimestampAction::SelectStrategy(
                                 TimestampStrategyAction::SasRules,
                             ),
-                        ));
+                        );
                     }
                 });
                 ui.label("• Use when project names follow SAS conventions for deterministic scheduling.");
@@ -140,11 +155,12 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                         && app.packer_state.timestamp_strategy != TimestampStrategy::Manual
                         && strategy == TimestampStrategy::Manual
                     {
-                        app.trigger_action(Action::Timestamp(
+                        dispatch_timestamp_action(
+                            app,
                             TimestampAction::SelectStrategy(
                                 TimestampStrategyAction::Manual,
                             ),
-                        ));
+                        );
                     }
                 });
                 ui.label("• Use when you must pin the archive to an explicit, reviewer-approved timestamp.");
@@ -152,9 +168,10 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
 
                 if strategy == TimestampStrategy::Manual {
                     if app.packer_state.manual_timestamp.is_none() {
-                        app.trigger_action(Action::Timestamp(
+                        dispatch_timestamp_action(
+                            app,
                             TimestampAction::SetManualTimestamp(Some(default_timestamp)),
-                        ));
+                        );
                     }
                 }
 
@@ -203,15 +220,17 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                         if let Some(new_time) = NaiveTime::from_hms_opt(hour, minute, second) {
                             timestamp = NaiveDateTime::new(date, new_time);
                             if app.packer_state.manual_timestamp != Some(timestamp) {
-                                app.trigger_action(Action::Timestamp(
+                                dispatch_timestamp_action(
+                                    app,
                                     TimestampAction::SetManualTimestamp(Some(timestamp)),
-                                ));
+                                );
                             }
                         }
                     } else if app.packer_state.manual_timestamp != Some(timestamp) {
-                        app.trigger_action(Action::Timestamp(
+                        dispatch_timestamp_action(
+                            app,
                             TimestampAction::SetManualTimestamp(Some(timestamp)),
-                        ));
+                        );
                     }
 
                     if let Some(ts) = app.packer_state.manual_timestamp {
@@ -221,9 +240,10 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                     if let Some(planned) = planned_timestamp {
                         if ui.button("Copy planned timestamp").clicked() {
                             if app.packer_state.manual_timestamp != Some(planned) {
-                                app.trigger_action(Action::Timestamp(
+                                dispatch_timestamp_action(
+                                    app,
                                     TimestampAction::SetManualTimestamp(Some(planned)),
-                                ));
+                                );
                             }
                         }
                     }
@@ -238,9 +258,10 @@ pub(crate) fn metadata_timestamp_section(app: &mut PackerApp, ui: &mut egui::Ui)
                 TimestampStrategy::SasRules => TimestampStrategyAction::SasRules,
                 TimestampStrategy::Manual => TimestampStrategyAction::Manual,
             };
-            app.trigger_action(Action::Timestamp(TimestampAction::SelectStrategy(
-                strategy_action,
-            )));
+            dispatch_timestamp_action(
+                app,
+                TimestampAction::SelectStrategy(strategy_action),
+            );
         }
 
         ui.add_space(8.0);
@@ -370,12 +391,11 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
                         .speed(1.0),
                 )
                 .changed()
-                && app
-                    .packer_state
-                    .timestamp_rules_ui
-                    .set_seconds_between_items(seconds)
             {
-                app.mark_timestamp_rules_modified();
+                dispatch_timestamp_action(
+                    app,
+                    TimestampAction::Rules(TimestampRulesAction::SetSecondsBetweenItems(seconds)),
+                );
             }
             ui.end_row();
 
@@ -388,12 +408,11 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
                         .speed(10.0),
                 )
                 .changed()
-                && app
-                    .packer_state
-                    .timestamp_rules_ui
-                    .set_slots_per_category(slots)
             {
-                app.mark_timestamp_rules_modified();
+                dispatch_timestamp_action(
+                    app,
+                    TimestampAction::Rules(TimestampRulesAction::SetSlotsPerCategory(slots)),
+                );
             }
             ui.end_row();
         });
@@ -406,7 +425,6 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
     ui.small("Toggle canonical aliases to map known unprefixed names to their categories.");
     ui.add_space(6.0);
 
-    let mut move_request: Option<(usize, MoveDirection)> = None;
     let category_len = app.packer_state.timestamp_rules_ui.len();
 
     for index in 0..category_len {
@@ -416,7 +434,6 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
         let key = category.key().to_string();
         let alias_count = category.alias_count();
         let available_aliases = category.available_aliases().to_vec();
-        let _ = category;
 
         let header_title = if alias_count == 1 {
             format!("{key} (1 alias)")
@@ -424,7 +441,6 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
             format!("{key} ({alias_count} aliases)")
         };
 
-        let mut aliases_changed = false;
         egui::CollapsingHeader::new(header_title)
             .id_source(format!("timestamp_category_{index}"))
             .show(ui, |ui| {
@@ -433,13 +449,19 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
                         .add_enabled(index > 0, egui::Button::new("Move up"))
                         .clicked()
                     {
-                        move_request = Some((index, MoveDirection::Up));
+                        dispatch_timestamp_action(
+                            app,
+                            TimestampAction::Rules(TimestampRulesAction::MoveCategoryUp(index)),
+                        );
                     }
                     if ui
                         .add_enabled(index + 1 < category_len, egui::Button::new("Move down"))
                         .clicked()
                     {
-                        move_request = Some((index, MoveDirection::Down));
+                        dispatch_timestamp_action(
+                            app,
+                            TimestampAction::Rules(TimestampRulesAction::MoveCategoryDown(index)),
+                        );
                     }
                 });
 
@@ -455,13 +477,14 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
                             .map(|category| category.is_alias_selected(alias))
                             .unwrap_or(false);
                         if ui.checkbox(&mut is_selected, alias).changed() {
-                            if app.packer_state.timestamp_rules_ui.set_alias_selected(
-                                index,
-                                alias,
-                                is_selected,
-                            ) {
-                                aliases_changed = true;
-                            }
+                            dispatch_timestamp_action(
+                                app,
+                                TimestampAction::Rules(TimestampRulesAction::SetAliasSelected {
+                                    category_index: index,
+                                    alias: alias.to_string(),
+                                    selected: is_selected,
+                                }),
+                            );
                         }
                     }
 
@@ -472,30 +495,13 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
                 }
             });
 
-        if aliases_changed {
-            app.mark_timestamp_rules_modified();
-        }
-
         ui.add_space(6.0);
-    }
-
-    if let Some((index, direction)) = move_request {
-        let moved = match direction {
-            MoveDirection::Up => app.packer_state.timestamp_rules_ui.move_category_up(index),
-            MoveDirection::Down => app
-                .packer_state
-                .timestamp_rules_ui
-                .move_category_down(index),
-        };
-        if moved {
-            app.mark_timestamp_rules_modified();
-        }
     }
 
     ui.add_space(10.0);
     ui.horizontal(|ui| {
         if ui.button("Restore defaults").clicked() {
-            app.reset_timestamp_rules_to_default();
+            dispatch_timestamp_action(app, TimestampAction::ResetRulesToDefault);
         }
 
         let save_enabled = app.packer_state.folder.is_some();
@@ -512,7 +518,7 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
                         app.packer_state.timestamp_strategy,
                         TimestampStrategy::SasRules
                     ) {
-                        app.apply_planned_timestamp();
+                        dispatch_timestamp_action(app, TimestampAction::ApplyPlannedTimestamp);
                     }
                 }
                 Err(err) => app.set_error_message(err),
@@ -529,7 +535,7 @@ pub(crate) fn timestamp_rules_editor(app: &mut PackerApp, ui: &mut egui::Ui) {
                     app.packer_state.timestamp_strategy,
                     TimestampStrategy::SasRules
                 ) {
-                    app.apply_planned_timestamp();
+                    dispatch_timestamp_action(app, TimestampAction::ApplyPlannedTimestamp);
                 }
             }
         }
@@ -541,16 +547,10 @@ fn default_timestamp() -> NaiveDateTime {
     now.with_nanosecond(0).unwrap_or(now)
 }
 
-#[derive(Clone, Copy)]
-enum MoveDirection {
-    Up,
-    Down,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{PackerApp, SasPrefix, TimestampStrategy};
+    use crate::{PackerApp, SasPrefix};
     use chrono::{Duration, NaiveDate};
     use eframe::egui;
 
@@ -562,8 +562,11 @@ mod tests {
             .and_hms_opt(3, 4, 5)
             .unwrap();
         app.packer_state.source_timestamp = Some(source);
-        app.set_timestamp_strategy(TimestampStrategy::InheritSource);
-        app.refresh_timestamp_from_strategy();
+        dispatch_timestamp_action(
+            &mut app,
+            TimestampAction::SelectStrategy(TimestampStrategyAction::InheritSource),
+        );
+        dispatch_timestamp_action(&mut app, TimestampAction::RefreshFromStrategy);
 
         let rendered = render_metadata_text(&mut app);
 
@@ -581,8 +584,11 @@ mod tests {
         app.packer_state.source_timestamp = None;
         app.packer_state.set_selected_prefix(SasPrefix::App);
         app.packer_state.set_folder_base_name("TEST".to_string());
-        app.set_timestamp_strategy(TimestampStrategy::SasRules);
-        app.refresh_timestamp_from_strategy();
+        dispatch_timestamp_action(
+            &mut app,
+            TimestampAction::SelectStrategy(TimestampStrategyAction::SasRules),
+        );
+        dispatch_timestamp_action(&mut app, TimestampAction::RefreshFromStrategy);
 
         let rendered = render_metadata_text(&mut app);
 
@@ -596,12 +602,15 @@ mod tests {
     fn manual_summary_updates_after_manual_timestamp_change() {
         let mut app = PackerApp::default();
         app.packer_state.source_timestamp = None;
-        app.set_timestamp_strategy(TimestampStrategy::Manual);
+        dispatch_timestamp_action(
+            &mut app,
+            TimestampAction::SelectStrategy(TimestampStrategyAction::Manual),
+        );
         let initial = NaiveDate::from_ymd_opt(2024, 5, 6)
             .unwrap()
             .and_hms_opt(7, 8, 9)
             .unwrap();
-        let _ = app.packer_state.set_manual_timestamp(Some(initial));
+        dispatch_timestamp_action(&mut app, TimestampAction::SetManualTimestamp(Some(initial)));
 
         let rendered = render_metadata_text(&mut app);
         assert!(rendered.contains(
@@ -609,7 +618,7 @@ mod tests {
         ));
 
         let updated = initial + Duration::minutes(5);
-        app.packer_state.set_manual_timestamp(Some(updated));
+        dispatch_timestamp_action(&mut app, TimestampAction::SetManualTimestamp(Some(updated)));
 
         let rerendered = render_metadata_text(&mut app);
         assert!(rerendered.contains(


### PR DESCRIPTION
## Summary
- add TimestampRulesAction variants and IconSysAction::ApplyPreset so gui-core can represent preset selection and timestamp rule edits through shared intents
- teach AppState and PackerApp to process the new actions, including applying icon.sys presets via ICON_SYS_PRESETS and marking timestamp rules modified when edits occur
- rework the icon.sys and timestamp UI to dispatch through helper functions instead of mutating state directly, and update timestamp unit tests accordingly

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d47ace389c832180c4b134e2307ddc